### PR TITLE
chore: add systemd service unit and install script

### DIFF
--- a/gemma-rpi-agent.service
+++ b/gemma-rpi-agent.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Gemma 4 Raspberry Pi Telegram Bot
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/gemma-rpi-agent
+EnvironmentFile=/root/gemma-rpi-agent/.env
+ExecStart=/root/gemma-rpi-agent/.venv/bin/python bot.py
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/install-service.sh
+++ b/install-service.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE=gemma-rpi-agent
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cp "$REPO_DIR/$SERVICE.service" /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable "$SERVICE"
+systemctl restart "$SERVICE"
+systemctl status "$SERVICE" --no-pager


### PR DESCRIPTION
## Summary
- Adds `gemma-rpi-agent.service` — systemd unit that runs the bot under the `root` user, reads secrets from `.env`, restarts on failure
- Adds `install-service.sh` — one-shot script to deploy the unit, enable, and start the service

## How to deploy on the Pi
```bash
sudo bash install-service.sh
```

## Notes
- **Service files are included** — touching these affects the live systemd-managed deployment on the Pi (see dev-flow rules)
- `.env` is still never committed; the service reads it via `EnvironmentFile=`

## Test plan
- [ ] Run `sudo bash install-service.sh` on the Pi
- [ ] Verify `systemctl status gemma-rpi-agent` shows `active (running)`
- [ ] Send a Telegram message and confirm the bot responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)