### PR TITLE
feat: restrict bot access via ALLOWED_USER_IDS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 TELEGRAM_TOKEN=your_bot_token_here
 SYSTEM_PROMPT=You are a helpful assistant running on a Raspberry Pi.
+# Comma-separated Telegram user IDs allowed to chat with the bot.
+# Leave empty/unset to allow everyone.
+ALLOWED_USER_IDS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ The llama.cpp server must already be running on `http://127.0.0.1:8080` before s
 |---|---|---|
 | `TELEGRAM_TOKEN` | Yes | — |
 | `SYSTEM_PROMPT` | No | `"You are a helpful assistant running on a Raspberry Pi."` |
+| `ALLOWED_USER_IDS` | No | empty (allow all) — comma/whitespace-separated Telegram user IDs; if set, other users are silently ignored and logged |
 
 ## Architecture
 

--- a/bot.py
+++ b/bot.py
@@ -23,6 +23,11 @@ load_dotenv()
 
 TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
 SYSTEM_PROMPT = os.getenv("SYSTEM_PROMPT", "You are a helpful assistant running on a Raspberry Pi.")
+# Comma- or whitespace-separated Telegram user IDs allowed to talk to the bot.
+# Empty/unset means no restriction (all users allowed).
+ALLOWED_USER_IDS: set[int] = {
+    int(x) for x in os.getenv("ALLOWED_USER_IDS", "").replace(",", " ").split() if x.strip()
+}
 LLAMA_URL = "http://127.0.0.1:8080/v1/chat/completions"
 MODEL = "gemma4"
 CURSOR = "▌"
@@ -41,6 +46,20 @@ histories: dict[int, list[dict]] = {}
 
 def fresh_history() -> list[dict]:
     return [{"role": "system", "content": SYSTEM_PROMPT}]
+
+
+def is_allowed(update: Update) -> bool:
+    if not ALLOWED_USER_IDS:
+        return True
+    user = update.effective_user
+    if user is None or user.id not in ALLOWED_USER_IDS:
+        log.warning(
+            "Rejected message from unauthorized user id=%s username=%s",
+            getattr(user, "id", None),
+            getattr(user, "username", None),
+        )
+        return False
+    return True
 
 
 def sys_footer() -> str:
@@ -121,6 +140,9 @@ def split_point(text: str, max_len: int) -> int:
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_allowed(update):
+        return
+
     chat_id = update.effective_chat.id
     user_text = update.message.text.strip()
 
@@ -173,6 +195,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_allowed(update):
+        return
     chat_id = update.effective_chat.id
     histories[chat_id] = fresh_history()
     await update.message.reply_text(
@@ -184,11 +208,15 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def cmd_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_allowed(update):
+        return
     histories[update.effective_chat.id] = fresh_history()
     await update.message.reply_text("Conversation cleared.")
 
 
 async def cmd_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_allowed(update):
+        return
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             r = await client.get("http://127.0.0.1:8080/health")


### PR DESCRIPTION
## Summary
- New optional env var \`ALLOWED_USER_IDS\` (comma or whitespace separated Telegram user IDs).
- All handlers (\`handle_message\`, \`/start\`, \`/clear\`, \`/model\`) check the caller's id; unauthorized users are logged and silently ignored.
- Empty/unset keeps the previous allow-all behavior, so existing deploys without the var set are unaffected.
- Docs updated (\`CLAUDE.md\` env table, \`.env.example\`).

## Impact
- Affects the live bot path in \`bot.py\`. On the Pi, set \`ALLOWED_USER_IDS\` in \`.env\` and restart the systemd service for it to take effect.

## Test plan
- [x] \`python -m py_compile bot.py\`
- [x] Parse logic smoke test with \`ALLOWED_USER_IDS='1283394836, 400898602'\`
- [ ] Restart service, confirm allowed user still gets replies
- [ ] Confirm an unauthorized test account gets no reply and appears in the journal as a rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)