### PR TITLE
chore: ignore .claude/ local settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyo
 .DS_Store
 logs/
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so local Claude Code settings and skills stay out of the repo.

## Test plan
- [x] `.gitignore` entry present; `git status` no longer shows `.claude/` as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)