### PR TITLE
feat: sqlite schema and test infra for vocab agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ __pycache__/
 *.pyo
 .DS_Store
 logs/
+data/
 .claude/
+.pytest_cache/

--- a/db.py
+++ b/db.py
@@ -1,0 +1,71 @@
+"""SQLite persistence for vocab, chat settings, and push history.
+
+Schema is created on first `init_db()` call and is idempotent. FSRS columns on
+`words` are written as NULL until a word is rated; see `vocab.py` (added in a
+later change) for FSRS integration.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+DEFAULT_DB_PATH = Path(__file__).resolve().parent / "data" / "vocab.db"
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS chats (
+    chat_id        INTEGER PRIMARY KEY,
+    tz             TEXT    NOT NULL,
+    pushes_per_day INTEGER NOT NULL DEFAULT 3,
+    active_start   TEXT    NOT NULL DEFAULT '09:00',
+    active_end     TEXT    NOT NULL DEFAULT '21:00',
+    tone           TEXT    NOT NULL DEFAULT 'mixed',
+    created_at     TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS words (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id        INTEGER NOT NULL,
+    text           TEXT    NOT NULL,
+    added_at       TEXT    NOT NULL,
+    mention_count  INTEGER NOT NULL DEFAULT 0,
+    last_used_at   TEXT,
+    stability      REAL,
+    difficulty     REAL,
+    state          INTEGER NOT NULL DEFAULT 0,
+    due            TEXT,
+    reps           INTEGER NOT NULL DEFAULT 0,
+    lapses         INTEGER NOT NULL DEFAULT 0,
+    last_review    TEXT,
+    UNIQUE(chat_id, text),
+    FOREIGN KEY(chat_id) REFERENCES chats(chat_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_words_chat ON words(chat_id);
+
+CREATE TABLE IF NOT EXISTS push_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id        INTEGER NOT NULL,
+    sent_at        TEXT    NOT NULL,
+    tg_message_id  INTEGER,
+    word_ids_json  TEXT    NOT NULL,
+    rated          INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY(chat_id) REFERENCES chats(chat_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_push_log_chat ON push_log(chat_id);
+"""
+
+
+def connect(db_path: Path | str = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    """Open a connection with sensible pragmas for a single-writer bot."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, isolation_level=None, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Create tables if they don't exist. Safe to call on every startup."""
+    conn.executescript(SCHEMA)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import db as db_mod
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    """Fresh initialized SQLite connection backed by a tmp file."""
+    c = db_mod.connect(tmp_path / "vocab.db")
+    db_mod.init_db(c)
+    try:
+        yield c
+    finally:
+        c.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,85 @@
+"""Schema-level tests for db.py."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import db as db_mod
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    return {r["name"] for r in rows}
+
+
+def test_init_creates_expected_tables(conn: sqlite3.Connection) -> None:
+    assert {"chats", "words", "push_log"}.issubset(_tables(conn))
+
+
+def test_init_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "vocab.db"
+    c = db_mod.connect(path)
+    db_mod.init_db(c)
+    db_mod.init_db(c)  # second call must not raise
+    assert {"chats", "words", "push_log"}.issubset(_tables(c))
+    c.close()
+
+
+def test_words_unique_per_chat(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'ephemeral', '2026-04-21')"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'ephemeral', '2026-04-21')"
+        )
+
+
+def test_same_word_allowed_across_chats(conn: sqlite3.Connection) -> None:
+    for chat_id in (1, 2):
+        conn.execute(
+            "INSERT INTO chats(chat_id, tz, created_at) VALUES (?, 'UTC', '2026-04-21')",
+            (chat_id,),
+        )
+        conn.execute(
+            "INSERT INTO words(chat_id, text, added_at) VALUES (?, 'ephemeral', '2026-04-21')",
+            (chat_id,),
+        )
+    count = conn.execute("SELECT COUNT(*) AS n FROM words").fetchone()["n"]
+    assert count == 2
+
+
+def test_cascade_delete_chat_removes_words_and_pushes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (7, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (7, 'placid', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO push_log(chat_id, sent_at, word_ids_json) VALUES (7, '2026-04-21', '[1]')"
+    )
+    conn.execute("DELETE FROM chats WHERE chat_id = 7")
+    assert conn.execute("SELECT COUNT(*) AS n FROM words").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) AS n FROM push_log").fetchone()["n"] == 0
+
+
+def test_words_default_fsrs_state_is_new(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'serendipity', '2026-04-21')"
+    )
+    row = conn.execute("SELECT state, stability, difficulty FROM words").fetchone()
+    assert row["state"] == 0
+    assert row["stability"] is None
+    assert row["difficulty"] is None


### PR DESCRIPTION
## Summary
- Adds `db.py`: SQLite schema for `chats`, `words` (with FSRS columns reserved), and `push_log`, plus a `connect()` helper with WAL + foreign keys on.
- Bootstraps a `tests/` directory with pytest fixtures and 6 schema-level tests (creation, idempotency, unique-per-chat, cross-chat dedupe, cascade delete, FSRS default state).
- Adds `requirements-dev.txt` so the Pi runtime doesn't pull in pytest.
- Gitignores `data/` (DB lives there) and `.pytest_cache/`.

No runtime behavior change — `bot.py` is untouched. This is the foundation for the vocab agent; word CRUD, FSRS selection, scheduler, and bot wire-up follow in separate PRs.

## Test plan
- [x] `python -m py_compile bot.py db.py`
- [x] `python -m pytest -q` → 6 passed
- [ ] Confirm `data/` appears ignored after the first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)