### PR TITLE
feat: vocab CRUD and literal mention scanning

### DIFF
--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,0 +1,136 @@
+"""Tests for vocab.py — CRUD + mention scanning."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import vocab
+
+
+CHAT = 100
+
+
+def _all_words(conn: sqlite3.Connection) -> list[str]:
+    return [r["text"] for r in conn.execute("SELECT text FROM words").fetchall()]
+
+
+def test_add_word_returns_true_for_new(conn: sqlite3.Connection) -> None:
+    assert vocab.add_word(conn, CHAT, "ephemeral") is True
+    assert _all_words(conn) == ["ephemeral"]
+
+
+def test_add_word_returns_false_for_duplicate(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "ephemeral")
+    assert vocab.add_word(conn, CHAT, "ephemeral") is False
+    assert len(_all_words(conn)) == 1
+
+
+def test_add_word_normalizes_case_and_whitespace(conn: sqlite3.Connection) -> None:
+    assert vocab.add_word(conn, CHAT, "  Serendipity  ") is True
+    assert vocab.add_word(conn, CHAT, "SERENDIPITY") is False
+    assert _all_words(conn) == ["serendipity"]
+
+
+def test_add_empty_raises(conn: sqlite3.Connection) -> None:
+    with pytest.raises(ValueError):
+        vocab.add_word(conn, CHAT, "   ")
+
+
+def test_add_word_auto_creates_chat(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "placid")
+    row = conn.execute("SELECT chat_id FROM chats WHERE chat_id = ?", (CHAT,)).fetchone()
+    assert row is not None
+
+
+def test_remove_word_returns_true_when_present(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "placid")
+    assert vocab.remove_word(conn, CHAT, "placid") is True
+    assert _all_words(conn) == []
+
+
+def test_remove_word_returns_false_when_absent(conn: sqlite3.Connection) -> None:
+    assert vocab.remove_word(conn, CHAT, "nope") is False
+
+
+def test_remove_word_is_case_insensitive(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "Placid")
+    assert vocab.remove_word(conn, CHAT, "PLACID") is True
+
+
+def test_list_all_orders_by_mention_count_then_recent(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "old_high")
+    vocab.add_word(conn, CHAT, "old_low")
+    vocab.add_word(conn, CHAT, "new_low")
+
+    conn.execute("UPDATE words SET mention_count = 5 WHERE text = 'old_high'")
+    # Push old_low's added_at earlier so new_low sorts above it for same count.
+    conn.execute("UPDATE words SET added_at = '2020-01-01' WHERE text = 'old_low'")
+
+    rows = vocab.list_words(conn, CHAT)
+    # Expected: both count=0 words first (newest first), then count=5.
+    assert [r["text"] for r in rows] == ["new_low", "old_low", "old_high"]
+
+
+def test_list_filters_by_substring(conn: sqlite3.Connection) -> None:
+    for w in ("cat", "concatenate", "dog"):
+        vocab.add_word(conn, CHAT, w)
+    rows = vocab.list_words(conn, CHAT, contains="cat")
+    assert sorted(r["text"] for r in rows) == ["cat", "concatenate"]
+
+
+def test_list_scopes_to_chat(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, 1, "alpha")
+    vocab.add_word(conn, 2, "beta")
+    rows = vocab.list_words(conn, 1)
+    assert [r["text"] for r in rows] == ["alpha"]
+
+
+def test_scan_mentions_matches_case_insensitive_substrings() -> None:
+    words = [(1, "ephemeral"), (2, "serendipity"), (3, "placid")]
+    text = "It was a Serendipity moment, brief and EPHEMERAL."
+    assert sorted(vocab.scan_mentions(text, words)) == [1, 2]
+
+
+def test_scan_mentions_matches_phrases() -> None:
+    words = [(1, "on the fly"), (2, "by the book")]
+    text = "He figured it out on the fly, no rehearsal."
+    assert vocab.scan_mentions(text, words) == [1]
+
+
+def test_scan_mentions_counts_each_word_once() -> None:
+    words = [(1, "cat")]
+    text = "cat cat cat cat"
+    assert vocab.scan_mentions(text, words) == [1]
+
+
+def test_scan_mentions_empty_inputs() -> None:
+    assert vocab.scan_mentions("", []) == []
+    assert vocab.scan_mentions("hello world", []) == []
+    assert vocab.scan_mentions("", [(1, "hello")]) == []
+
+
+def test_bump_mentions_increments_and_timestamps(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "placid")
+    wid = conn.execute("SELECT id FROM words").fetchone()["id"]
+
+    vocab.bump_mentions(conn, [wid])
+    vocab.bump_mentions(conn, [wid])
+
+    row = conn.execute(
+        "SELECT mention_count, last_used_at FROM words WHERE id = ?", (wid,)
+    ).fetchone()
+    assert row["mention_count"] == 2
+    assert row["last_used_at"] is not None
+
+
+def test_bump_mentions_noop_on_empty_list(conn: sqlite3.Connection) -> None:
+    vocab.bump_mentions(conn, [])  # must not raise
+
+
+def test_ensure_chat_is_idempotent(conn: sqlite3.Connection) -> None:
+    vocab.ensure_chat(conn, 42, tz="Europe/Warsaw")
+    vocab.ensure_chat(conn, 42, tz="UTC")  # second call must not overwrite
+    row = conn.execute("SELECT tz FROM chats WHERE chat_id = 42").fetchone()
+    assert row["tz"] == "Europe/Warsaw"

--- a/vocab.py
+++ b/vocab.py
@@ -1,0 +1,109 @@
+"""Vocabulary CRUD and literal mention scanning.
+
+Words are normalized to lowercased, stripped form on write and scanned
+case-insensitively. Substring (literal) matching is intentional for this stage
+— no lemmatization, no stemming. A mention bumps `mention_count` once per
+scan call regardless of how many times the word literally appears.
+
+FSRS state on words is left to a later change; this module only touches the
+CRUD / mention-count columns.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sqlite3
+
+
+def _now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _normalize(text: str) -> str:
+    return text.strip().lower()
+
+
+def ensure_chat(conn: sqlite3.Connection, chat_id: int, tz: str = "UTC") -> None:
+    """Insert a chat row with defaults if one doesn't already exist.
+
+    The real /start config flow (added later) overwrites these defaults; this
+    helper exists so vocab ops can create a chat row on demand and satisfy the
+    words.chat_id foreign key.
+    """
+    conn.execute(
+        "INSERT OR IGNORE INTO chats(chat_id, tz, created_at) VALUES (?, ?, ?)",
+        (chat_id, tz, _now()),
+    )
+
+
+def add_word(conn: sqlite3.Connection, chat_id: int, text: str) -> bool:
+    """Add a word/phrase. Returns True if newly inserted, False if a duplicate."""
+    word = _normalize(text)
+    if not word:
+        raise ValueError("word must be non-empty")
+    ensure_chat(conn, chat_id)
+    cur = conn.execute(
+        "INSERT OR IGNORE INTO words(chat_id, text, added_at) VALUES (?, ?, ?)",
+        (chat_id, word, _now()),
+    )
+    return cur.rowcount > 0
+
+
+def remove_word(conn: sqlite3.Connection, chat_id: int, text: str) -> bool:
+    """Remove by exact normalized match. Returns True if a row was deleted."""
+    word = _normalize(text)
+    if not word:
+        return False
+    cur = conn.execute(
+        "DELETE FROM words WHERE chat_id = ? AND text = ?",
+        (chat_id, word),
+    )
+    return cur.rowcount > 0
+
+
+def list_words(
+    conn: sqlite3.Connection,
+    chat_id: int,
+    contains: str | None = None,
+) -> list[sqlite3.Row]:
+    """All words for a chat, optionally filtered by substring.
+
+    Ordered by mention_count ASC, then added_at DESC — surfaces the least-
+    mentioned and newest additions first, which is what `/list` wants.
+    """
+    if contains:
+        needle = f"%{_normalize(contains)}%"
+        return conn.execute(
+            "SELECT * FROM words "
+            "WHERE chat_id = ? AND text LIKE ? "
+            "ORDER BY mention_count ASC, added_at DESC",
+            (chat_id, needle),
+        ).fetchall()
+    return conn.execute(
+        "SELECT * FROM words WHERE chat_id = ? "
+        "ORDER BY mention_count ASC, added_at DESC",
+        (chat_id,),
+    ).fetchall()
+
+
+def scan_mentions(text: str, words: list[tuple[int, str]]) -> list[int]:
+    """Return ids of vocab words that appear as literal substrings in `text`.
+
+    Case-insensitive. Stored words are assumed already-normalized. Each word
+    contributes to the result at most once regardless of occurrence count.
+    """
+    haystack = text.lower()
+    return [wid for wid, w in words if w and w in haystack]
+
+
+def bump_mentions(conn: sqlite3.Connection, word_ids: list[int]) -> None:
+    """Increment mention_count and update last_used_at for the given word ids."""
+    if not word_ids:
+        return
+    now = _now()
+    conn.executemany(
+        "UPDATE words "
+        "SET mention_count = mention_count + 1, last_used_at = ? "
+        "WHERE id = ?",
+        [(now, wid) for wid in word_ids],
+    )


### PR DESCRIPTION
## Summary
- `vocab.py`: `add_word`, `remove_word`, `list_words` (optional substring filter), `scan_mentions` (case-insensitive literal substring match), `bump_mentions`, and an idempotent `ensure_chat` helper.
- Words are normalized to lowercased+stripped form on insert; `/list` orders by `mention_count ASC, added_at DESC` so least-seen and newest surface first.
- 18 new pytest cases covering dedupe, normalization, phrase matching, cross-chat isolation, and bump semantics (each scan contributes at most once per word).
- No `bot.py` wiring yet — still library-level.

## Test plan
- [x] `python -m py_compile bot.py db.py vocab.py`
- [x] `python -m pytest -q` → 24 passed
- [ ] PR3 will plug this into FSRS state and the selection formula
- [ ] PR6 will wire `/add`, `/remove`, `/list` into `bot.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)