### PR TITLE
feat: FSRS rating and weighted word selection

### DIFF
--- a/db.py
+++ b/db.py
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS words (
     stability      REAL,
     difficulty     REAL,
     state          INTEGER NOT NULL DEFAULT 0,
+    step           INTEGER,
     due            TEXT,
     reps           INTEGER NOT NULL DEFAULT 0,
     lapses         INTEGER NOT NULL DEFAULT 0,
@@ -66,6 +67,16 @@ def connect(db_path: Path | str = DEFAULT_DB_PATH) -> sqlite3.Connection:
     return conn
 
 
+def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {r["name"] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
 def init_db(conn: sqlite3.Connection) -> None:
-    """Create tables if they don't exist. Safe to call on every startup."""
+    """Create tables if they don't exist. Safe to call on every startup.
+
+    Also applies small forward-only migrations for columns added after the
+    initial schema — keeps existing on-disk dbs usable.
+    """
     conn.executescript(SCHEMA)
+    if "step" not in _column_names(conn, "words"):
+        conn.execute("ALTER TABLE words ADD COLUMN step INTEGER")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot>=20.7
 httpx>=0.27.0
 python-dotenv>=1.0.0
+fsrs>=6.3

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,164 @@
+"""FSRS rating + selection-formula tests."""
+
+from __future__ import annotations
+
+import datetime
+import random
+import sqlite3
+
+import pytest
+from fsrs import Rating
+
+import vocab
+
+
+CHAT = 500
+UTC = datetime.timezone.utc
+
+
+def _wid(conn: sqlite3.Connection, text: str) -> int:
+    return conn.execute(
+        "SELECT id FROM words WHERE chat_id=? AND text=?", (CHAT, text)
+    ).fetchone()["id"]
+
+
+def _set_added(conn: sqlite3.Connection, text: str, days_ago: float) -> None:
+    ts = datetime.datetime.now(UTC) - datetime.timedelta(days=days_ago)
+    conn.execute(
+        "UPDATE words SET added_at = ? WHERE chat_id = ? AND text = ?",
+        (ts.strftime(vocab._TS_FMT), CHAT, text),
+    )
+
+
+# --- rate_word ---------------------------------------------------------------
+
+
+def test_rate_good_initializes_fsrs_state(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "ephemeral")
+    wid = _wid(conn, "ephemeral")
+    vocab.rate_word(conn, wid, Rating.Good)
+    row = conn.execute("SELECT * FROM words WHERE id=?", (wid,)).fetchone()
+    assert row["stability"] is not None
+    assert row["difficulty"] is not None
+    assert row["state"] in (1, 2, 3)
+    assert row["reps"] == 1
+    assert row["lapses"] == 0
+    assert row["mention_count"] == 1
+    assert row["last_used_at"] is not None
+    assert row["last_review"] is not None
+
+
+def test_rate_again_increments_lapses(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "placid")
+    wid = _wid(conn, "placid")
+    vocab.rate_word(conn, wid, Rating.Good)
+    vocab.rate_word(conn, wid, Rating.Again)
+    row = conn.execute("SELECT reps, lapses FROM words WHERE id=?", (wid,)).fetchone()
+    assert row["reps"] == 2
+    assert row["lapses"] == 1
+
+
+def test_rate_preserves_state_across_calls(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "lucid")
+    wid = _wid(conn, "lucid")
+    t = datetime.datetime.now(UTC)
+    vocab.rate_word(conn, wid, Rating.Good, at=t)
+    first = conn.execute(
+        "SELECT stability, difficulty FROM words WHERE id=?", (wid,)
+    ).fetchone()
+    vocab.rate_word(conn, wid, Rating.Good, at=t + datetime.timedelta(days=1))
+    second = conn.execute(
+        "SELECT stability, difficulty FROM words WHERE id=?", (wid,)
+    ).fetchone()
+    # Successful review should grow stability.
+    assert second["stability"] > first["stability"]
+
+
+def test_rate_unknown_word_raises(conn: sqlite3.Connection) -> None:
+    with pytest.raises(KeyError):
+        vocab.rate_word(conn, 999999, Rating.Good)
+
+
+# --- compute_weight ----------------------------------------------------------
+
+
+def test_weight_for_fresh_unrated_word_is_near_eight(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "brandnew")
+    row = conn.execute(
+        "SELECT * FROM words WHERE text='brandnew'"
+    ).fetchone()
+    # forget_prob=1, recency≈1, rarity=1 → (1+1)*(1+1)*(1+1) = 8
+    w = vocab.compute_weight(row, datetime.datetime.now(UTC))
+    assert 7.9 < w <= 8.0
+
+
+def test_rarity_boost_shrinks_with_mentions(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "seen_often")
+    conn.execute(
+        "UPDATE words SET mention_count = 9 WHERE text = 'seen_often'"
+    )
+    row = conn.execute("SELECT * FROM words WHERE text='seen_often'").fetchone()
+    # rarity = 1/(1+9) = 0.1 → factor (1+0.1) = 1.1
+    # forget_prob=1, recency≈1 → (2)*(2)*(1.1) = 4.4
+    w = vocab.compute_weight(row, datetime.datetime.now(UTC))
+    assert 4.3 < w < 4.5
+
+
+def test_recency_boost_decays_with_age(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "aged")
+    _set_added(conn, "aged", days_ago=14.0)  # exp(-14/7) = exp(-2) ≈ 0.135
+    row = conn.execute("SELECT * FROM words WHERE text='aged'").fetchone()
+    # forget_prob=1, recency≈0.135, rarity=1 → 2 * 1.135 * 2 ≈ 4.54
+    w = vocab.compute_weight(row, datetime.datetime.now(UTC))
+    assert 4.4 < w < 4.7
+
+
+def test_weight_drops_for_just_learned_word(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "mastered")
+    wid = _wid(conn, "mastered")
+    vocab.rate_word(conn, wid, Rating.Good)
+    row = conn.execute("SELECT * FROM words WHERE id=?", (wid,)).fetchone()
+    # Just rated Good → retrievability ≈ 1, forget_prob ≈ 0 → (1+0)*(…)*(…) << 8
+    w = vocab.compute_weight(row, datetime.datetime.now(UTC))
+    assert w < 4.5
+
+
+# --- select_word -------------------------------------------------------------
+
+
+def test_select_returns_none_when_empty(conn: sqlite3.Connection) -> None:
+    vocab.ensure_chat(conn, CHAT)
+    assert vocab.select_word(conn, CHAT) is None
+
+
+def test_select_returns_only_candidate(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "only_option")
+    picked = vocab.select_word(conn, CHAT, rng=random.Random(0))
+    assert picked["text"] == "only_option"
+
+
+def test_select_prefers_new_and_unmentioned_in_aggregate(
+    conn: sqlite3.Connection,
+) -> None:
+    # fresh: just added, zero mentions → weight ≈ 8
+    # worn: added 30 days ago, mentioned 9 times → weight ≈ 2 * 1.014 * 1.1 ≈ 2.23
+    vocab.add_word(conn, CHAT, "fresh")
+    vocab.add_word(conn, CHAT, "worn")
+    _set_added(conn, "worn", days_ago=30.0)
+    conn.execute("UPDATE words SET mention_count = 9 WHERE text = 'worn'")
+
+    rng = random.Random(42)
+    picks = [
+        vocab.select_word(conn, CHAT, rng=rng)["text"] for _ in range(400)
+    ]
+    # With weights ~8 vs ~2.2 the odds are ~3.6:1 in favour of "fresh".
+    fresh_count = picks.count("fresh")
+    assert fresh_count > picks.count("worn")
+    assert fresh_count > 300  # ~78% expected, leaves margin for sampling noise
+
+
+def test_select_scopes_to_chat(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, 1, "alpha")
+    vocab.add_word(conn, 2, "beta")
+    picked = vocab.select_word(conn, 1, rng=random.Random(0))
+    assert picked["text"] == "alpha"

--- a/vocab.py
+++ b/vocab.py
@@ -1,22 +1,59 @@
-"""Vocabulary CRUD and literal mention scanning.
+"""Vocabulary CRUD, literal mention scanning, FSRS rating, and word selection.
 
 Words are normalized to lowercased, stripped form on write and scanned
 case-insensitively. Substring (literal) matching is intentional for this stage
-— no lemmatization, no stemming. A mention bumps `mention_count` once per
-scan call regardless of how many times the word literally appears.
+— no lemmatization, no stemming.
 
-FSRS state on words is left to a later change; this module only touches the
-CRUD / mention-count columns.
+FSRS drives per-word memory state (stability/difficulty/due via py-fsrs with
+desired_retention=0.95 and maximum_interval=7d so reviews stay tight). Push
+selection samples a word using a multiplicative weight:
+
+    weight = (1 + forget_prob) * (1 + recency_boost) * (1 + rarity_boost)
+
+so no single signal dominates and randomness is baked into `random.choices`.
 """
 
 from __future__ import annotations
 
 import datetime
+import math
+import random
 import sqlite3
+
+from fsrs import Card, Rating, Scheduler, State
+
+
+FSRS_RETENTION = 0.95
+FSRS_MAX_DAYS = 7
+RECENCY_TAU_DAYS = 7.0
+
+# enable_fuzzing=False → deterministic intervals, easier to test and reason about.
+_SCHEDULER = Scheduler(
+    desired_retention=FSRS_RETENTION,
+    maximum_interval=FSRS_MAX_DAYS,
+    enable_fuzzing=False,
+)
+
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def _now_dt() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 def _now() -> str:
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return _now_dt().strftime(_TS_FMT)
+
+
+def _parse_ts(s: str) -> datetime.datetime:
+    """Parse both our short UTC format and py-fsrs's ISO-8601 strings."""
+    try:
+        return datetime.datetime.strptime(s, _TS_FMT).replace(
+            tzinfo=datetime.timezone.utc
+        )
+    except ValueError:
+        return datetime.datetime.fromisoformat(s)
 
 
 def _normalize(text: str) -> str:
@@ -107,3 +144,94 @@ def bump_mentions(conn: sqlite3.Connection, word_ids: list[int]) -> None:
         "WHERE id = ?",
         [(now, wid) for wid in word_ids],
     )
+
+
+def _card_from_row(row: sqlite3.Row) -> Card:
+    """Reconstruct a py-fsrs Card from a word row, or a fresh one if unrated."""
+    if row["stability"] is None:
+        return Card()
+    return Card(
+        state=State(row["state"]) if row["state"] else State.Learning,
+        step=row["step"],
+        stability=row["stability"],
+        difficulty=row["difficulty"],
+        due=_parse_ts(row["due"]) if row["due"] else None,
+        last_review=_parse_ts(row["last_review"]) if row["last_review"] else None,
+    )
+
+
+def rate_word(
+    conn: sqlite3.Connection,
+    word_id: int,
+    rating: Rating,
+    *,
+    at: datetime.datetime | None = None,
+) -> None:
+    """Apply an FSRS rating, bump mention_count, and stamp last_used_at.
+
+    `at` pins the review time (useful for tests / backfilled pushes); defaults
+    to now.
+    """
+    at = at or _now_dt()
+    row = conn.execute("SELECT * FROM words WHERE id = ?", (word_id,)).fetchone()
+    if row is None:
+        raise KeyError(word_id)
+    card = _card_from_row(row)
+    new_card, _log = _SCHEDULER.review_card(card, rating, review_datetime=at)
+    lapses = row["lapses"] + (1 if rating == Rating.Again else 0)
+    conn.execute(
+        "UPDATE words SET "
+        "stability = ?, difficulty = ?, state = ?, step = ?, due = ?, "
+        "reps = reps + 1, lapses = ?, last_review = ?, "
+        "mention_count = mention_count + 1, last_used_at = ? "
+        "WHERE id = ?",
+        (
+            new_card.stability,
+            new_card.difficulty,
+            new_card.state.value,
+            new_card.step,
+            new_card.due.isoformat() if new_card.due else None,
+            lapses,
+            new_card.last_review.isoformat() if new_card.last_review else None,
+            at.strftime(_TS_FMT),
+            word_id,
+        ),
+    )
+
+
+def _forget_prob(row: sqlite3.Row, now: datetime.datetime) -> float:
+    """1 - FSRS retrievability. Unrated words → 1.0 (maximal urgency)."""
+    if row["stability"] is None:
+        return 1.0
+    return 1.0 - _SCHEDULER.get_card_retrievability(
+        _card_from_row(row), current_datetime=now
+    )
+
+
+def compute_weight(row: sqlite3.Row, now: datetime.datetime) -> float:
+    """Selection weight for a word. Each factor lives in [0, 1] and is lifted
+    to [1, 2] so no single signal can dominate the product."""
+    forget_prob = _forget_prob(row, now)
+    age_days = (now - _parse_ts(row["added_at"])).total_seconds() / 86400.0
+    recency_boost = math.exp(-max(age_days, 0.0) / RECENCY_TAU_DAYS)
+    rarity_boost = 1.0 / (1.0 + row["mention_count"])
+    return (1 + forget_prob) * (1 + recency_boost) * (1 + rarity_boost)
+
+
+def select_word(
+    conn: sqlite3.Connection,
+    chat_id: int,
+    *,
+    rng: random.Random | None = None,
+    now: datetime.datetime | None = None,
+) -> sqlite3.Row | None:
+    """Sample one word for this chat using the weighted formula. None if empty."""
+    now = now or _now_dt()
+    rows = conn.execute(
+        "SELECT * FROM words WHERE chat_id = ?", (chat_id,)
+    ).fetchall()
+    if not rows:
+        return None
+    weights = [compute_weight(r, now) for r in rows]
+    pick = (rng or random).choices(rows, weights=weights, k=1)
+    return pick[0]


### PR DESCRIPTION
## Summary
- Integrates `py-fsrs` (`desired_retention=0.95`, `maximum_interval=7d`, fuzzing off) so reviews stay tight instead of growing into month-long intervals.
- `vocab.rate_word(word_id, Rating.Good|Again)` — runs the FSRS review, persists stability/difficulty/state/step/due/reps/lapses/last_review, and bumps `mention_count` + `last_used_at`.
- `vocab.select_word(chat_id)` — samples one word via `random.choices` with weight `(1 + forget_prob) * (1 + recency_boost) * (1 + rarity_boost)`. Unrated words get `forget_prob=1` (max urgency), recency decays on a 7-day half-life, rarity is `1/(1+mentions)`.
- Adds a `step` column to `words` for full FSRS round-trip, with a forward-only ALTER on `init_db()` so existing dbs stay usable.
- `fsrs>=6.3` added to `requirements.txt` (runtime).

## Test plan
- [x] `python -m py_compile bot.py db.py vocab.py`
- [x] `python -m pytest -q` → 36 passed
- [x] Formula spot-checks (brand-new word ≈ 8; mention_count=9 ≈ 4.4; age=14d ≈ 4.5)
- [x] Deterministic weighted sampling with a seeded `random.Random`
- [ ] PR5 schedules push delivery on top of this
- [ ] PR6 wires the rating buttons into a callback handler

## Impact
No runtime behavior change to `bot.py` yet. Installing the new dep is required (`pip install -r requirements.txt`) before PR6 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)