### PR TITLE
refactor: extract llm client and add prompt templates

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,13 +3,11 @@
 
 import asyncio
 import datetime
-import json
 import logging
 import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-import httpx
 from dotenv import load_dotenv
 from telegram import Update
 from telegram.error import RetryAfter, BadRequest
@@ -22,6 +20,8 @@ from telegram.ext import (
 )
 from telegram.request import HTTPXRequest
 
+import llm
+
 load_dotenv()
 
 TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
@@ -31,8 +31,6 @@ SYSTEM_PROMPT = os.getenv("SYSTEM_PROMPT", "You are a helpful assistant running 
 ALLOWED_USER_IDS: set[int] = {
     int(x) for x in os.getenv("ALLOWED_USER_IDS", "").replace(",", " ").split() if x.strip()
 }
-LLAMA_URL = "http://127.0.0.1:8080/v1/chat/completions"
-MODEL = "gemma4"
 CURSOR = "▌"
 EDIT_INTERVAL = 2.0   # seconds between Telegram message edits (rate-limit safe)
 MAX_MSG_LEN = 4000    # Telegram hard limit is 4096; responses past this spill into new messages
@@ -114,36 +112,6 @@ def sys_footer() -> str:
     return f"\n\n`load {load1:.2f} {load5:.2f} {load15:.2f} | {temp_str}`"
 
 
-async def stream_llama(messages: list[dict]):
-    """Async-stream token chunks from the llama.cpp OpenAI-compatible endpoint."""
-    async with httpx.AsyncClient(timeout=180) as client:
-        async with client.stream(
-            "POST",
-            LLAMA_URL,
-            json={
-                "model": MODEL,
-                "messages": messages,
-                "max_tokens": 1024,
-                "temperature": 0.7,
-                "stream": True,
-            },
-        ) as resp:
-            resp.raise_for_status()
-            async for raw in resp.aiter_lines():
-                if not raw.startswith("data:"):
-                    continue
-                data = raw[5:].strip()
-                if data == "[DONE]":
-                    break
-                try:
-                    chunk = json.loads(data)
-                    delta = chunk["choices"][0]["delta"].get("content", "")
-                    if delta:
-                        yield delta
-                except (json.JSONDecodeError, KeyError):
-                    continue
-
-
 async def safe_edit(message, text: str) -> None:
     """Edit a Telegram message, handling rate-limit and no-change errors."""
     try:
@@ -205,7 +173,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     last_edit = asyncio.get_event_loop().time()
 
     try:
-        async for token in stream_llama(histories[chat_id]):
+        async for token in llm.stream_chat(histories[chat_id]):
             accumulated += token
             current_page += token
 
@@ -266,16 +234,10 @@ async def cmd_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def cmd_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not is_allowed(update):
         return
-    try:
-        async with httpx.AsyncClient(timeout=5) as client:
-            r = await client.get("http://127.0.0.1:8080/health")
-            status = r.json().get("status", "unknown")
-    except Exception as e:
-        status = f"unreachable ({e})"
-
+    status = await llm.health()
     await update.message.reply_text(
-        f"Model: {MODEL}\n"
-        f"Endpoint: {LLAMA_URL}\n"
+        f"Model: {llm.MODEL}\n"
+        f"Endpoint: {llm.LLAMA_URL}\n"
         f"Server status: {status}"
     )
 

--- a/llm.py
+++ b/llm.py
@@ -1,0 +1,103 @@
+"""Thin async client for llama.cpp's OpenAI-compatible HTTP server.
+
+Exposes three entry points:
+  * `stream_chat(messages)` — async generator yielding token deltas for live
+    Telegram message edits.
+  * `chat(messages)` — non-streaming one-shot, used by the push scheduler where
+    we wait for the full reply before sending.
+  * `health()` — status string for /model.
+
+SSE parsing and non-stream response parsing are factored into pure helpers so
+they can be unit-tested without standing up an HTTP mock.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import AsyncIterator
+
+import httpx
+
+
+LLAMA_BASE = "http://127.0.0.1:8080"
+LLAMA_URL = f"{LLAMA_BASE}/v1/chat/completions"
+HEALTH_URL = f"{LLAMA_BASE}/health"
+MODEL = "gemma4"
+
+_DONE = "[DONE]"
+
+
+def _parse_sse_delta(raw: str) -> str | None:
+    """Return the content delta from one SSE line, or None to skip/terminate."""
+    if not raw.startswith("data:"):
+        return None
+    payload = raw[5:].strip()
+    if not payload or payload == _DONE:
+        return None
+    try:
+        chunk = json.loads(payload)
+        return chunk["choices"][0]["delta"].get("content") or None
+    except (json.JSONDecodeError, KeyError, IndexError):
+        return None
+
+
+def _parse_completion(payload: dict) -> str:
+    return payload["choices"][0]["message"].get("content", "")
+
+
+async def stream_chat(
+    messages: list[dict],
+    *,
+    max_tokens: int = 1024,
+    temperature: float = 0.7,
+) -> AsyncIterator[str]:
+    """Stream token deltas from llama.cpp as they arrive."""
+    async with httpx.AsyncClient(timeout=180) as client:
+        async with client.stream(
+            "POST",
+            LLAMA_URL,
+            json={
+                "model": MODEL,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "stream": True,
+            },
+        ) as resp:
+            resp.raise_for_status()
+            async for raw in resp.aiter_lines():
+                delta = _parse_sse_delta(raw)
+                if delta:
+                    yield delta
+
+
+async def chat(
+    messages: list[dict],
+    *,
+    max_tokens: int = 256,
+    temperature: float = 0.8,
+) -> str:
+    """Return the full assistant reply as a single string (no streaming)."""
+    async with httpx.AsyncClient(timeout=180) as client:
+        r = await client.post(
+            LLAMA_URL,
+            json={
+                "model": MODEL,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "stream": False,
+            },
+        )
+        r.raise_for_status()
+        return _parse_completion(r.json())
+
+
+async def health() -> str:
+    """Return the llama.cpp server's self-reported status, or an error string."""
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.get(HEALTH_URL)
+            return r.json().get("status", "unknown")
+    except Exception as e:  # noqa: BLE001 — surface the reason verbatim to the user
+        return f"unreachable ({e})"

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,72 @@
+"""Prompt templates for scheduled pushes and just-talk replies.
+
+Pushes and chat replies share one style rule: answers should be at most 1–2
+short paragraphs. Push prompts additionally require the target vocab word to
+appear literally (used by the scheduler's retry-once check).
+"""
+
+from __future__ import annotations
+
+import random
+
+TONES: tuple[str, ...] = ("funny", "motivational", "scary", "bright")
+
+_TONE_INSTRUCTIONS: dict[str, str] = {
+    "funny": "Write a playful, lightly absurd mini-scene. Make the reader smile.",
+    "motivational": "Write a warm, sincere micro-pep-talk.",
+    "scary": "Write a brief, eerie moment — atmospheric dread, not gore.",
+    "bright": "Write a vivid, sensory, sunlit snapshot full of small wonders.",
+}
+
+_PUSH_SYSTEM = (
+    "You write tiny English snippets that use a given vocabulary word naturally. "
+    "Keep it to 1–2 short sentences, at most 2 short paragraphs. "
+    "The word MUST appear literally in your reply (same spelling, case-insensitive). "
+    "No headings, no quotes, no explanation — just the snippet."
+)
+
+_JUST_TALK_TAIL = "\nKeep answers short: 1–2 paragraphs at most."
+
+_JUST_TALK_VOCAB = (
+    "\nThe user is studying an English vocabulary list. "
+    "If any of these words fit naturally in your reply, use them: {words}. "
+    "Do not force words in; skip them entirely when they don't fit the answer."
+)
+
+
+def resolve_tone(tone: str, rng: random.Random | None = None) -> str:
+    """Expand "mixed" to a concrete tone; validate otherwise."""
+    if tone == "mixed":
+        return (rng or random).choice(TONES)
+    if tone not in _TONE_INSTRUCTIONS:
+        raise ValueError(f"unknown tone: {tone!r}")
+    return tone
+
+
+def push_messages(
+    word: str,
+    tone: str,
+    *,
+    rng: random.Random | None = None,
+) -> list[dict]:
+    """Build the messages payload for a scheduled push using `word`."""
+    resolved = resolve_tone(tone, rng=rng)
+    return [
+        {
+            "role": "system",
+            "content": f"{_PUSH_SYSTEM}\n{_TONE_INSTRUCTIONS[resolved]}",
+        },
+        {"role": "user", "content": f"Word to use: {word}"},
+    ]
+
+
+def just_talk_system(base: str, vocab_words: list[str]) -> str:
+    """Compose the system prompt for a plain-text chat reply.
+
+    Appends a short note reminding the model to keep replies tight and — if the
+    user has vocabulary loaded — to use those words when they fit naturally.
+    """
+    prompt = base + _JUST_TALK_TAIL
+    if vocab_words:
+        prompt += _JUST_TALK_VOCAB.format(words=", ".join(vocab_words))
+    return prompt

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,40 @@
+"""Tests for llm.py parse helpers (no network)."""
+
+from __future__ import annotations
+
+import llm
+
+
+def test_sse_delta_extracts_content() -> None:
+    line = 'data: {"choices":[{"delta":{"content":"hello"}}]}'
+    assert llm._parse_sse_delta(line) == "hello"
+
+
+def test_sse_delta_returns_none_on_done() -> None:
+    assert llm._parse_sse_delta("data: [DONE]") is None
+
+
+def test_sse_delta_returns_none_on_non_data_line() -> None:
+    assert llm._parse_sse_delta("event: ping") is None
+    assert llm._parse_sse_delta("") is None
+
+
+def test_sse_delta_tolerates_empty_delta() -> None:
+    # Some llama.cpp builds emit {"delta":{}} for the opening chunk.
+    line = 'data: {"choices":[{"delta":{}}]}'
+    assert llm._parse_sse_delta(line) is None
+
+
+def test_sse_delta_tolerates_junk_payload() -> None:
+    assert llm._parse_sse_delta("data: not-json") is None
+    assert llm._parse_sse_delta('data: {"choices":[]}') is None
+
+
+def test_parse_completion_returns_content() -> None:
+    payload = {"choices": [{"message": {"content": "paragraph here"}}]}
+    assert llm._parse_completion(payload) == "paragraph here"
+
+
+def test_parse_completion_missing_content_returns_empty() -> None:
+    payload = {"choices": [{"message": {}}]}
+    assert llm._parse_completion(payload) == ""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,61 @@
+"""Tests for prompts.py."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+import prompts
+
+
+def test_resolve_tone_passes_through_fixed() -> None:
+    for t in prompts.TONES:
+        assert prompts.resolve_tone(t) == t
+
+
+def test_resolve_tone_expands_mixed_with_seed() -> None:
+    r = random.Random(0)
+    chosen = prompts.resolve_tone("mixed", rng=r)
+    assert chosen in prompts.TONES
+
+
+def test_resolve_tone_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        prompts.resolve_tone("whimsical")
+
+
+def test_push_messages_has_system_and_user_with_word() -> None:
+    msgs = prompts.push_messages("ephemeral", "funny")
+    assert [m["role"] for m in msgs] == ["system", "user"]
+    assert "ephemeral" in msgs[1]["content"]
+    # Push system prompt must demand literal appearance of the word.
+    assert "literally" in msgs[0]["content"].lower()
+
+
+def test_push_messages_mixed_tone_uses_rng() -> None:
+    msgs = prompts.push_messages("placid", "mixed", rng=random.Random(0))
+    # The system prompt contains one of the concrete tone instructions.
+    sys = msgs[0]["content"]
+    assert any(
+        snippet[:20] in sys
+        for snippet in [
+            "Write a playful",
+            "Write a warm",
+            "Write a brief, eerie",
+            "Write a vivid",
+        ]
+    )
+
+
+def test_just_talk_system_without_vocab_just_appends_length_rule() -> None:
+    out = prompts.just_talk_system("You are helpful.", [])
+    assert out.startswith("You are helpful.")
+    assert "1–2 paragraphs" in out
+    assert "vocabulary list" not in out
+
+
+def test_just_talk_system_with_vocab_includes_words() -> None:
+    out = prompts.just_talk_system("You are helpful.", ["ephemeral", "placid"])
+    assert "ephemeral" in out and "placid" in out
+    assert "vocabulary list" in out


### PR DESCRIPTION
## Summary
- `llm.py`: `stream_chat`, `chat` (one-shot for pushes), `health`. SSE delta and completion parsing factored into pure helpers for unit testing.
- `prompts.py`: `push_messages(word, tone)` with tone instructions for funny/motivational/scary/bright (plus `mixed` → random each push), and `just_talk_system(base, vocab_words)` that keeps replies short and nudges vocab use only when it fits.
- `bot.py` now imports `llm.stream_chat` instead of defining its own generator; `/model` uses `llm.health()`. No behavior change — pure extraction.
- 14 new pytest cases (SSE/completion parsers, tone resolution, push/just-talk message shape). Total: **50 passed**.

## Test plan
- [x] `python -m py_compile bot.py db.py vocab.py llm.py prompts.py`
- [x] `python -m pytest -q` → 50 passed
- [ ] Manual smoke: run `bot.py`, send a message, confirm streaming still edits live (I haven't; flagging here since `bot.py` imports changed)
- [ ] PR5 schedules pushes using `prompts.push_messages` + `llm.chat`
- [ ] PR6 uses `prompts.just_talk_system` for the plain-text reply path

## Impact
`bot.py` lost ~45 lines and gained `import llm`. Constants `LLAMA_URL` / `MODEL` now live in `llm.py` only. The live bot on the Pi needs `git pull` but no new deps (all pre-installed by PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)