### PR TITLE
feat: config flow and push scheduler primitives

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -1,0 +1,191 @@
+"""Per-chat settings and the /start conversation state machine.
+
+Kept separate from Telegram so the step logic can be unit-tested. `bot.py`
+(PR6) owns the wiring — it creates a `ConfigSession` on `/start`, feeds it
+each plain-text reply, and on `done` persists via `save_settings`.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import sqlite3
+from dataclasses import dataclass, asdict
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+TONES = ("funny", "motivational", "scary", "bright", "mixed")
+MIN_PUSHES = 1
+MAX_PUSHES = 8
+
+
+@dataclass
+class Settings:
+    tz: str
+    pushes_per_day: int
+    active_start: str  # "HH:MM"
+    active_end: str
+    tone: str
+
+
+def validate_tz(s: str) -> str:
+    name = s.strip()
+    try:
+        ZoneInfo(name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(
+            f"Unknown timezone {name!r}. Try e.g. Europe/Warsaw or UTC."
+        ) from exc
+    return name
+
+
+def validate_pushes(s: str) -> int:
+    try:
+        n = int(s.strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"Send a whole number between {MIN_PUSHES} and {MAX_PUSHES}."
+        ) from exc
+    if not MIN_PUSHES <= n <= MAX_PUSHES:
+        raise ValueError(f"Pick a number between {MIN_PUSHES} and {MAX_PUSHES}.")
+    return n
+
+
+_HHMM_RE = re.compile(r"^([01]?\d|2[0-3]):([0-5]\d)$")
+
+
+def validate_hhmm(s: str) -> str:
+    m = _HHMM_RE.match(s.strip())
+    if not m:
+        raise ValueError("Use 24h HH:MM format, e.g. 09:00 or 21:30.")
+    h, mi = int(m.group(1)), int(m.group(2))
+    return f"{h:02d}:{mi:02d}"
+
+
+def validate_tone(s: str) -> str:
+    v = s.strip().lower()
+    if v not in TONES:
+        raise ValueError(f"Pick one of: {', '.join(TONES)}.")
+    return v
+
+
+# Step definitions: (field, prompt, validator).
+_STEPS = [
+    ("tz", "What timezone? (e.g. Europe/Warsaw, UTC)", validate_tz),
+    (
+        "pushes_per_day",
+        f"How many pushes per day? ({MIN_PUSHES}–{MAX_PUSHES})",
+        validate_pushes,
+    ),
+    (
+        "active_start",
+        "Active window start? (HH:MM, e.g. 09:00)",
+        validate_hhmm,
+    ),
+    (
+        "active_end",
+        "Active window end? (HH:MM, e.g. 21:00)",
+        validate_hhmm,
+    ),
+    (
+        "tone",
+        "Tone preference? (funny / motivational / scary / bright / mixed)",
+        validate_tone,
+    ),
+]
+
+INTRO = "Let's configure your vocab agent.\n\n"
+DONE_MESSAGE = (
+    "✅ All set. Add words with `/add <word>` and pushes will start "
+    "showing up in your active window."
+)
+
+
+class ConfigSession:
+    """Tracks a single chat's position while walking the /start steps."""
+
+    def __init__(self) -> None:
+        self.idx: int = 0
+        self.partial: dict[str, object] = {}
+
+    @property
+    def done(self) -> bool:
+        return self.idx >= len(_STEPS)
+
+    def first_prompt(self) -> str:
+        return INTRO + _STEPS[0][1]
+
+    def current_prompt(self) -> str:
+        if self.done:
+            return DONE_MESSAGE
+        return _STEPS[self.idx][1]
+
+    def submit(self, text: str) -> tuple[bool, str]:
+        """Feed a user reply. Returns (advanced, reply_text).
+
+        On validation error the session stays on the same step and returns a
+        human-readable message. On the final step `advanced=True, reply=DONE`.
+        """
+        if self.done:
+            return False, DONE_MESSAGE
+        field, _, validator = _STEPS[self.idx]
+        try:
+            value = validator(text)
+        except ValueError as exc:
+            return False, f"⚠️ {exc}"
+        self.partial[field] = value
+        self.idx += 1
+        if self.done:
+            return True, DONE_MESSAGE
+        return True, _STEPS[self.idx][1]
+
+    def settings(self) -> Settings:
+        if not self.done:
+            raise RuntimeError("config session not complete")
+        return Settings(**self.partial)  # type: ignore[arg-type]
+
+
+def save_settings(
+    conn: sqlite3.Connection, chat_id: int, settings: Settings
+) -> None:
+    """Upsert the chat's configuration row."""
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, pushes_per_day, active_start, active_end, tone, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT(chat_id) DO UPDATE SET "
+        "tz=excluded.tz, pushes_per_day=excluded.pushes_per_day, "
+        "active_start=excluded.active_start, active_end=excluded.active_end, "
+        "tone=excluded.tone",
+        (
+            chat_id,
+            settings.tz,
+            settings.pushes_per_day,
+            settings.active_start,
+            settings.active_end,
+            settings.tone,
+            now,
+        ),
+    )
+
+
+def load_settings(
+    conn: sqlite3.Connection, chat_id: int
+) -> Settings | None:
+    row = conn.execute(
+        "SELECT tz, pushes_per_day, active_start, active_end, tone "
+        "FROM chats WHERE chat_id = ?",
+        (chat_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return Settings(
+        tz=row["tz"],
+        pushes_per_day=row["pushes_per_day"],
+        active_start=row["active_start"],
+        active_end=row["active_end"],
+        tone=row["tone"],
+    )
+
+
+def settings_as_dict(s: Settings) -> dict:
+    return asdict(s)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot>=20.7
 httpx>=0.27.0
 python-dotenv>=1.0.0
 fsrs>=6.3
+APScheduler>=3.10

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,265 @@
+"""Push scheduling primitives and the APScheduler wrapper.
+
+Split into a pure planning core (tested directly) and a thin `PushRunner`
+wrapper that owns the AsyncIOScheduler. Production dispatch (sending on
+Telegram, attaching rating buttons) is injected by `bot.py` so this module
+stays free of telegram imports.
+
+`plan_push_times` picks randomized times inside the active window using
+equal-sized buckets with a half-gap buffer at bucket edges — so consecutive
+pushes can't cluster against the boundary.
+
+`compose_push` runs one cycle: select a word, prompt the LLM, retry once if
+the word didn't appear literally. Persistence of the sent message is the
+caller's job so bot.py can include the Telegram message id.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import random
+import sqlite3
+from typing import Awaitable, Callable
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+import config_flow
+import prompts
+import vocab
+
+
+log = logging.getLogger(__name__)
+
+# Minimum gap between consecutive pushes (minutes). Enforced implicitly by the
+# bucket algorithm below.
+MIN_GAP_MIN = 45
+
+
+def _parse_hm(s: str) -> tuple[int, int]:
+    h, m = s.split(":")
+    return int(h), int(m)
+
+
+def plan_push_times(
+    date: datetime.date,
+    tz: str,
+    pushes_per_day: int,
+    active_start: str,
+    active_end: str,
+    *,
+    rng: random.Random | None = None,
+    min_gap_min: int = MIN_GAP_MIN,
+) -> list[datetime.datetime]:
+    """Pick `pushes_per_day` tz-aware datetimes within the active window.
+
+    Divides the window into equal buckets and samples one point per bucket
+    with a half-gap buffer at each bucket edge. Returns [] if the window is
+    zero-length or negative.
+    """
+    rng = rng or random
+    zone = ZoneInfo(tz)
+    sh, sm = _parse_hm(active_start)
+    eh, em = _parse_hm(active_end)
+    start = datetime.datetime.combine(date, datetime.time(sh, sm), tzinfo=zone)
+    end = datetime.datetime.combine(date, datetime.time(eh, em), tzinfo=zone)
+    window_min = int((end - start).total_seconds() // 60)
+    if window_min <= 0 or pushes_per_day <= 0:
+        return []
+
+    bucket = window_min / pushes_per_day
+    half_gap = min_gap_min / 2 if bucket > min_gap_min else 0.0
+
+    times: list[datetime.datetime] = []
+    for i in range(pushes_per_day):
+        lo = int(i * bucket + half_gap)
+        hi = int((i + 1) * bucket - half_gap) - 1
+        if hi < lo:
+            # Bucket too tight for the buffer; place at bucket center.
+            off = int(i * bucket + bucket / 2)
+        else:
+            off = rng.randint(lo, hi)
+        times.append(start + datetime.timedelta(minutes=off))
+    return times
+
+
+# Injected type aliases for clarity.
+LlmChat = Callable[[list[dict]], Awaitable[str]]
+
+
+async def compose_push(
+    conn: sqlite3.Connection,
+    chat_id: int,
+    *,
+    llm_chat: LlmChat,
+    rng: random.Random | None = None,
+    now: datetime.datetime | None = None,
+    retries: int = 1,
+) -> tuple[int, str, str] | None:
+    """Select a word and prompt the LLM. Returns (word_id, word, text) or None.
+
+    Retries once if the word doesn't appear literally in the output. On final
+    failure the text is returned anyway — rare with short vocab prompts and
+    better than dropping the push.
+    """
+    chat_row = conn.execute(
+        "SELECT tone FROM chats WHERE chat_id = ?", (chat_id,)
+    ).fetchone()
+    if chat_row is None:
+        return None
+    picked = vocab.select_word(conn, chat_id, rng=rng, now=now)
+    if picked is None:
+        return None
+
+    tone = chat_row["tone"]
+    word = picked["text"]
+    text = ""
+    for _ in range(retries + 1):
+        text = await llm_chat(prompts.push_messages(word, tone, rng=rng))
+        if word in text.lower():
+            break
+    return picked["id"], word, text
+
+
+def log_push(
+    conn: sqlite3.Connection,
+    chat_id: int,
+    tg_message_id: int | None,
+    word_ids: list[int],
+) -> int:
+    """Insert a push_log row; returns its id."""
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    cur = conn.execute(
+        "INSERT INTO push_log(chat_id, sent_at, tg_message_id, word_ids_json) "
+        "VALUES (?, ?, ?, ?)",
+        (chat_id, now, tg_message_id, json.dumps(word_ids)),
+    )
+    return cur.lastrowid
+
+
+def mark_rated(conn: sqlite3.Connection, push_id: int) -> None:
+    conn.execute("UPDATE push_log SET rated = 1 WHERE id = ?", (push_id,))
+
+
+def load_push(
+    conn: sqlite3.Connection, push_id: int
+) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM push_log WHERE id = ?", (push_id,)
+    ).fetchone()
+
+
+# --- APScheduler wrapper -----------------------------------------------------
+
+Dispatch = Callable[[int], Awaitable[None]]
+
+
+class PushRunner:
+    """Owns the AsyncIOScheduler and keeps per-chat jobs in sync with settings.
+
+    Two job kinds are registered per chat:
+      * `plan:<chat_id>` — fires daily at 00:01 local, re-rolls today's push
+        times (so they vary each day).
+      * `push:<chat_id>:<i>` — one-shot jobs for each planned time today.
+
+    `dispatch` is injected by bot.py and is an `async (chat_id) -> None` that
+    runs the actual compose + send + log_push flow.
+    """
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        dispatch: Dispatch,
+        *,
+        scheduler: AsyncIOScheduler | None = None,
+    ) -> None:
+        self.conn = conn
+        self.dispatch = dispatch
+        self.scheduler = scheduler or AsyncIOScheduler()
+
+    def start(self) -> None:
+        self.scheduler.start()
+
+    def stop(self) -> None:
+        self.scheduler.shutdown(wait=False)
+
+    def schedule_chat(
+        self, chat_id: int, settings: config_flow.Settings
+    ) -> list[datetime.datetime]:
+        """(Re)register all jobs for a chat; returns the push times scheduled today."""
+        self._remove_chat_jobs(chat_id)
+        zone = ZoneInfo(settings.tz)
+        today_times = self._plan_today(chat_id, settings)
+        self.scheduler.add_job(
+            self._plan_today_job,
+            CronTrigger(hour=0, minute=1, timezone=zone),
+            args=[chat_id, settings],
+            id=f"plan:{chat_id}",
+            replace_existing=True,
+        )
+        return today_times
+
+    def _plan_today_job(
+        self, chat_id: int, settings: config_flow.Settings
+    ) -> None:
+        self._plan_today(chat_id, settings)
+
+    def _plan_today(
+        self, chat_id: int, settings: config_flow.Settings
+    ) -> list[datetime.datetime]:
+        self._remove_push_jobs(chat_id)
+        zone = ZoneInfo(settings.tz)
+        now = datetime.datetime.now(zone)
+        times = plan_push_times(
+            now.date(),
+            settings.tz,
+            settings.pushes_per_day,
+            settings.active_start,
+            settings.active_end,
+        )
+        scheduled: list[datetime.datetime] = []
+        for i, t in enumerate(times):
+            if t <= now:
+                continue
+            self.scheduler.add_job(
+                self.dispatch,
+                DateTrigger(run_date=t),
+                args=[chat_id],
+                id=f"push:{chat_id}:{i}",
+                replace_existing=True,
+            )
+            scheduled.append(t)
+        log.info(
+            "Planned %d pushes for chat %s today: %s",
+            len(scheduled),
+            chat_id,
+            [t.isoformat(timespec="minutes") for t in scheduled],
+        )
+        return scheduled
+
+    def _remove_chat_jobs(self, chat_id: int) -> None:
+        for j in list(self.scheduler.get_jobs()):
+            if j.id.startswith(f"plan:{chat_id}") or j.id.startswith(
+                f"push:{chat_id}:"
+            ):
+                self.scheduler.remove_job(j.id)
+
+    def _remove_push_jobs(self, chat_id: int) -> None:
+        for j in list(self.scheduler.get_jobs()):
+            if j.id.startswith(f"push:{chat_id}:"):
+                self.scheduler.remove_job(j.id)
+
+    def refresh_all(self) -> None:
+        """Rebuild every chat's jobs — call on bot startup."""
+        rows = self.conn.execute(
+            "SELECT chat_id FROM chats"
+        ).fetchall()
+        for r in rows:
+            settings = config_flow.load_settings(self.conn, r["chat_id"])
+            if settings is None:
+                continue
+            self.schedule_chat(r["chat_id"], settings)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,134 @@
+"""Tests for config_flow.py — validators, session state machine, persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import config_flow
+
+
+# --- validators --------------------------------------------------------------
+
+
+def test_validate_tz_accepts_iana() -> None:
+    assert config_flow.validate_tz("Europe/Warsaw") == "Europe/Warsaw"
+    assert config_flow.validate_tz(" UTC ") == "UTC"
+
+
+def test_validate_tz_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        config_flow.validate_tz("Middle/Earth")
+
+
+def test_validate_pushes_accepts_range() -> None:
+    for n in range(config_flow.MIN_PUSHES, config_flow.MAX_PUSHES + 1):
+        assert config_flow.validate_pushes(str(n)) == n
+
+
+def test_validate_pushes_rejects_out_of_range() -> None:
+    for bad in ("0", "9", "-1", "lots"):
+        with pytest.raises(ValueError):
+            config_flow.validate_pushes(bad)
+
+
+def test_validate_hhmm_normalizes_to_two_digits() -> None:
+    assert config_flow.validate_hhmm("9:00") == "09:00"
+    assert config_flow.validate_hhmm("23:59") == "23:59"
+
+
+def test_validate_hhmm_rejects_bad_format() -> None:
+    for bad in ("24:00", "9", "nine", "9:60", "09-00"):
+        with pytest.raises(ValueError):
+            config_flow.validate_hhmm(bad)
+
+
+def test_validate_tone_lowercases_and_checks() -> None:
+    assert config_flow.validate_tone("Funny") == "funny"
+    assert config_flow.validate_tone("MIXED") == "mixed"
+
+
+def test_validate_tone_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        config_flow.validate_tone("whimsical")
+
+
+# --- ConfigSession -----------------------------------------------------------
+
+
+def _walk_happy_path(session: config_flow.ConfigSession) -> None:
+    for reply in ("Europe/Warsaw", "3", "09:00", "21:00", "mixed"):
+        advanced, _ = session.submit(reply)
+        assert advanced is True
+
+
+def test_session_completes_with_valid_replies() -> None:
+    s = config_flow.ConfigSession()
+    assert s.done is False
+    _walk_happy_path(s)
+    assert s.done is True
+    settings = s.settings()
+    assert settings.tz == "Europe/Warsaw"
+    assert settings.pushes_per_day == 3
+    assert settings.active_start == "09:00"
+    assert settings.active_end == "21:00"
+    assert settings.tone == "mixed"
+
+
+def test_session_stays_on_step_on_invalid_input() -> None:
+    s = config_flow.ConfigSession()
+    advanced, reply = s.submit("Middle/Earth")
+    assert advanced is False
+    assert "timezone" in reply.lower()
+    # Still on step 0
+    assert s.idx == 0
+    # Valid retry advances
+    advanced, _ = s.submit("UTC")
+    assert advanced is True
+    assert s.idx == 1
+
+
+def test_session_settings_raises_before_completion() -> None:
+    s = config_flow.ConfigSession()
+    with pytest.raises(RuntimeError):
+        s.settings()
+
+
+def test_session_submit_after_done_is_noop() -> None:
+    s = config_flow.ConfigSession()
+    _walk_happy_path(s)
+    advanced, reply = s.submit("anything")
+    assert advanced is False
+    assert reply == config_flow.DONE_MESSAGE
+
+
+# --- persistence -------------------------------------------------------------
+
+
+def test_save_and_load_settings_roundtrip(conn: sqlite3.Connection) -> None:
+    s = config_flow.Settings(
+        tz="UTC",
+        pushes_per_day=4,
+        active_start="08:00",
+        active_end="22:00",
+        tone="funny",
+    )
+    config_flow.save_settings(conn, 123, s)
+    loaded = config_flow.load_settings(conn, 123)
+    assert loaded == s
+
+
+def test_save_settings_upserts(conn: sqlite3.Connection) -> None:
+    first = config_flow.Settings("UTC", 3, "09:00", "21:00", "mixed")
+    second = config_flow.Settings("Europe/Warsaw", 5, "08:30", "23:00", "scary")
+    config_flow.save_settings(conn, 1, first)
+    config_flow.save_settings(conn, 1, second)
+    loaded = config_flow.load_settings(conn, 1)
+    assert loaded == second
+    count = conn.execute("SELECT COUNT(*) AS n FROM chats").fetchone()["n"]
+    assert count == 1
+
+
+def test_load_settings_missing_returns_none(conn: sqlite3.Connection) -> None:
+    assert config_flow.load_settings(conn, 999) is None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,293 @@
+"""Tests for scheduler.py planning core + push composer.
+
+APScheduler glue (PushRunner) is exercised lightly — we check job
+registration/removal without actually running the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import random
+import sqlite3
+
+import pytest
+
+import config_flow
+import scheduler
+import vocab
+
+
+CHAT = 700
+UTC = datetime.timezone.utc
+
+
+# --- plan_push_times ---------------------------------------------------------
+
+
+def test_plan_returns_empty_if_window_non_positive() -> None:
+    assert scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        3,
+        "21:00",
+        "09:00",
+    ) == []
+
+
+def test_plan_returns_empty_for_zero_pushes() -> None:
+    assert scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        0,
+        "09:00",
+        "21:00",
+    ) == []
+
+
+def test_plan_produces_requested_count() -> None:
+    times = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        4,
+        "09:00",
+        "21:00",
+        rng=random.Random(0),
+    )
+    assert len(times) == 4
+
+
+def test_plan_times_are_in_window_and_sorted() -> None:
+    rng = random.Random(0)
+    times = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        5,
+        "09:00",
+        "21:00",
+        rng=rng,
+    )
+    # All tz-aware UTC, strictly inside the window
+    start = datetime.datetime(2026, 4, 22, 9, 0, tzinfo=UTC)
+    end = datetime.datetime(2026, 4, 22, 21, 0, tzinfo=UTC)
+    for t in times:
+        assert start <= t <= end
+    # Sorted by construction (bucket index is monotonically increasing)
+    assert times == sorted(times)
+
+
+def test_plan_respects_min_gap_when_window_allows() -> None:
+    rng = random.Random(1)
+    times = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        4,
+        "09:00",
+        "21:00",  # 12h window → 180-min bucket, gap well above MIN_GAP_MIN
+        rng=rng,
+        min_gap_min=45,
+    )
+    gaps = [(b - a).total_seconds() / 60 for a, b in zip(times, times[1:])]
+    assert min(gaps) >= 45
+
+
+def test_plan_degrades_gracefully_on_tight_window() -> None:
+    # 60-min window, 3 pushes — bucket=20min, cannot satisfy 45-min gap.
+    # Should still produce 3 ordered times without raising.
+    times = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        3,
+        "09:00",
+        "10:00",
+        rng=random.Random(0),
+        min_gap_min=45,
+    )
+    assert len(times) == 3
+    assert times == sorted(times)
+
+
+def test_plan_is_deterministic_with_seeded_rng() -> None:
+    a = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        3,
+        "09:00",
+        "21:00",
+        rng=random.Random(42),
+    )
+    b = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        3,
+        "09:00",
+        "21:00",
+        rng=random.Random(42),
+    )
+    assert a == b
+
+
+# --- compose_push ------------------------------------------------------------
+
+
+def _seed_chat(conn: sqlite3.Connection, tone: str = "funny") -> None:
+    config_flow.save_settings(
+        conn,
+        CHAT,
+        config_flow.Settings("UTC", 2, "09:00", "21:00", tone),
+    )
+
+
+def test_compose_push_returns_none_if_chat_missing(conn: sqlite3.Connection) -> None:
+    async def llm_fail(msgs):  # should never be called
+        raise AssertionError("llm should not be called")
+
+    out = asyncio.run(
+        scheduler.compose_push(conn, CHAT, llm_chat=llm_fail)
+    )
+    assert out is None
+
+
+def test_compose_push_returns_none_if_no_words(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+
+    async def llm_fail(msgs):
+        raise AssertionError("llm should not be called")
+
+    out = asyncio.run(
+        scheduler.compose_push(conn, CHAT, llm_chat=llm_fail)
+    )
+    assert out is None
+
+
+def test_compose_push_returns_word_and_text_on_first_try(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "ephemeral")
+
+    calls: list[list[dict]] = []
+
+    async def llm_ok(msgs):
+        calls.append(msgs)
+        return "An ephemeral breeze stirred the page."
+
+    out = asyncio.run(
+        scheduler.compose_push(
+            conn, CHAT, llm_chat=llm_ok, rng=random.Random(0)
+        )
+    )
+    assert out is not None
+    _, word, text = out
+    assert word == "ephemeral"
+    assert "ephemeral" in text.lower()
+    assert len(calls) == 1
+
+
+def test_compose_push_retries_when_word_missing(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "ephemeral")
+
+    calls: list[list[dict]] = []
+
+    async def llm_flaky(msgs):
+        calls.append(msgs)
+        if len(calls) == 1:
+            return "Nothing to see here."  # word missing → should retry
+        return "The ephemeral mist lingered."
+
+    out = asyncio.run(
+        scheduler.compose_push(
+            conn, CHAT, llm_chat=llm_flaky, rng=random.Random(0)
+        )
+    )
+    assert out is not None
+    _, word, text = out
+    assert word == "ephemeral"
+    assert "ephemeral" in text.lower()
+    assert len(calls) == 2
+
+
+def test_compose_push_returns_anyway_after_retries(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "ephemeral")
+
+    async def llm_bad(msgs):
+        return "completely off-topic reply"
+
+    out = asyncio.run(
+        scheduler.compose_push(
+            conn, CHAT, llm_chat=llm_bad, rng=random.Random(0)
+        )
+    )
+    # With retries=1 we try 2 times and still return.
+    assert out is not None
+    _, word, text = out
+    assert word == "ephemeral"
+    assert "ephemeral" not in text.lower()
+
+
+# --- log_push / mark_rated ---------------------------------------------------
+
+
+def test_log_push_roundtrip(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    push_id = scheduler.log_push(conn, CHAT, tg_message_id=555, word_ids=[1, 2])
+    row = scheduler.load_push(conn, push_id)
+    assert row["chat_id"] == CHAT
+    assert row["tg_message_id"] == 555
+    assert row["rated"] == 0
+    assert row["word_ids_json"] == "[1, 2]"
+
+
+def test_mark_rated_sets_flag(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    push_id = scheduler.log_push(conn, CHAT, tg_message_id=1, word_ids=[1])
+    scheduler.mark_rated(conn, push_id)
+    row = scheduler.load_push(conn, push_id)
+    assert row["rated"] == 1
+
+
+# --- PushRunner (lightweight) ------------------------------------------------
+
+
+@pytest.fixture
+def runner(conn: sqlite3.Connection):
+    async def noop(chat_id: int) -> None:
+        return None
+
+    r = scheduler.PushRunner(conn, dispatch=noop)
+    yield r
+    # Clean up pending jobs; do not start the underlying scheduler so nothing fires.
+    for j in list(r.scheduler.get_jobs()):
+        r.scheduler.remove_job(j.id)
+
+
+def test_schedule_chat_adds_plan_and_push_jobs(
+    runner: scheduler.PushRunner, conn: sqlite3.Connection
+) -> None:
+    settings = config_flow.Settings("UTC", 3, "09:00", "21:00", "mixed")
+    config_flow.save_settings(conn, CHAT, settings)
+    runner.schedule_chat(CHAT, settings)
+    ids = {j.id for j in runner.scheduler.get_jobs()}
+    assert f"plan:{CHAT}" in ids
+    # At least one push job should be queued for today — unless the test is run
+    # very near local midnight, which we accept as a non-deterministic edge.
+    assert any(i.startswith(f"push:{CHAT}:") for i in ids) or any(
+        i == f"plan:{CHAT}" for i in ids
+    )
+
+
+def test_schedule_chat_is_idempotent(
+    runner: scheduler.PushRunner, conn: sqlite3.Connection
+) -> None:
+    settings = config_flow.Settings("UTC", 2, "00:00", "23:59", "mixed")
+    config_flow.save_settings(conn, CHAT, settings)
+    runner.schedule_chat(CHAT, settings)
+    first = {j.id for j in runner.scheduler.get_jobs()}
+    runner.schedule_chat(CHAT, settings)
+    second = {j.id for j in runner.scheduler.get_jobs()}
+    # Re-scheduling shouldn't leak stale jobs — plan id is stable; push ids
+    # are bounded by pushes_per_day.
+    assert f"plan:{CHAT}" in second
+    assert len([i for i in second if i.startswith(f"push:{CHAT}:")]) <= 2
+    # Cross-check: second run didn't accumulate extras beyond the first.
+    assert len(second) <= len(first)


### PR DESCRIPTION
## Summary
- `config_flow.py`: per-chat `Settings` dataclass, per-step validators (tz via `zoneinfo`, 1–8 pushes/day, HH:MM window, tone), a `ConfigSession` state machine for `/start`, and `save_settings` / `load_settings` with `ON CONFLICT` upsert.
- `scheduler.py` — split into pure core and APScheduler wrapper:
  - `plan_push_times` — equal-bucket sampling with a half-gap buffer at bucket edges so pushes can't cluster across a boundary.
  - `compose_push` — selects a word, prompts the LLM via the injected `llm_chat`, retries once if the word didn't appear literally.
  - `log_push` / `mark_rated` / `load_push` — `push_log` CRUD for PR6's rating callback.
  - `PushRunner` — wraps `AsyncIOScheduler`; registers a daily `plan:<chat>` cron at 00:01 local and one-shot `push:<chat>:<i>` jobs for today's planned times. Dispatch is injected; no telegram imports.
- `APScheduler>=3.10` added to `requirements.txt`.
- 31 new pytest cases (total: **81 passed**). Covers validators, session transitions, deterministic planning with seeded rng, min-gap enforcement, graceful degradation on tight windows, compose_push retry path, push_log roundtrip, runner idempotency.

## Test plan
- [x] `python -m py_compile` on every module
- [x] `python -m pytest -q` → 81 passed
- [ ] PR6 wires `PushRunner` into `bot.py` (injects dispatch = compose + send + log_push), adds `ConfigSession` handling in `/start`, wires the rating-button callback

## Impact
No `bot.py` changes — this PR is all new library code. The Pi needs `pip install -r requirements.txt` to pick up APScheduler before PR6 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)