### PR TITLE
fix: treat active_end "00:00" as end of day in plan_push_times

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -67,6 +67,10 @@ def plan_push_times(
     eh, em = _parse_hm(active_end)
     start = datetime.datetime.combine(date, datetime.time(sh, sm), tzinfo=zone)
     end = datetime.datetime.combine(date, datetime.time(eh, em), tzinfo=zone)
+    # "00:00" as active_end means end-of-day (the 24:00 boundary), not the
+    # same day's midnight — roll it forward one day so the window is positive.
+    if (eh, em) == (0, 0):
+        end += datetime.timedelta(days=1)
     window_min = int((end - start).total_seconds() // 60)
     if window_min <= 0 or pushes_per_day <= 0:
         return []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -35,6 +35,24 @@ def test_plan_returns_empty_if_window_non_positive() -> None:
     ) == []
 
 
+def test_plan_treats_midnight_end_as_end_of_day() -> None:
+    # active_end="00:00" should mean the 24:00 boundary, not the same day's
+    # midnight (which would make the window negative and return []).
+    times = scheduler.plan_push_times(
+        datetime.date(2026, 4, 22),
+        "UTC",
+        8,
+        "13:00",
+        "00:00",
+        rng=random.Random(0),
+    )
+    assert len(times) == 8
+    start = datetime.datetime(2026, 4, 22, 13, 0, tzinfo=UTC)
+    end = datetime.datetime(2026, 4, 23, 0, 0, tzinfo=UTC)
+    for t in times:
+        assert start <= t <= end
+
+
 def test_plan_returns_empty_for_zero_pushes() -> None:
     assert scheduler.plan_push_times(
         datetime.date(2026, 4, 22),


### PR DESCRIPTION
## Summary
- Fix `plan_push_times` returning `[]` when users set `active_end='00:00'` via `/start` — the window was being built as `13:00 → 00:00 same day`, giving a negative span, so **no pushes were ever scheduled**.
- Roll `end` forward one day when the end-of-window is `00:00` (midnight-as-end-of-day). Other wrap-around inputs (e.g. `21:00 → 09:00`) still return `[]` as before — those are ambiguous, not the common case.
- Add a regression test that would fail without the patch.

## Observed symptom
Production `bot.log` for an affected chat:
```
Planned 0 pushes for chat ... today: []
Config saved for chat ...: Settings(tz='Europe/Madrid', pushes_per_day=8, active_start='13:00', active_end='00:00', tone='mixed')
```

## Impact
- `scheduler.py`: one-line fix in the pure planning core. No handler or constant changes; `PushRunner` behavior unchanged.
- Live bot: after merge + restart, chats configured with end=`00:00` will actually receive their daily pushes.

## Test plan
- [x] `python -m py_compile bot.py scheduler.py`
- [x] `python -m pytest -q` — 82 passed (new test: `test_plan_treats_midnight_end_as_end_of_day`)
- [ ] After merge: restart the bot on the Pi and confirm the next `Planned N pushes …` log line for the affected chat is non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)