### PR TITLE
chore: reframe default SYSTEM_PROMPT as English tutor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 TELEGRAM_TOKEN=your_bot_token_here
-SYSTEM_PROMPT=You are a helpful assistant running on a Raspberry Pi.
+SYSTEM_PROMPT=You are a friendly English tutor chatting casually with a learner. Use natural, everyday English. If they ask about grammar, vocabulary, or usage, explain briefly with a small example.
 # Comma-separated Telegram user IDs allowed to chat with the bot.
 # Leave empty/unset to allow everyone.
 ALLOWED_USER_IDS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ The llama.cpp server must already be running on `http://127.0.0.1:8080` before s
 | Variable | Required | Default |
 |---|---|---|
 | `TELEGRAM_TOKEN` | Yes | — |
-| `SYSTEM_PROMPT` | No | `"You are a helpful assistant running on a Raspberry Pi."` |
+| `SYSTEM_PROMPT` | No | `"You are a friendly English tutor chatting casually with a learner. Use natural, everyday English. If they ask about grammar, vocabulary, or usage, explain briefly with a small example."` |
 | `ALLOWED_USER_IDS` | No | empty (allow all) — comma/whitespace-separated Telegram user IDs; if set, other users are silently ignored and logged |
 
 Per-chat scheduling settings (timezone, pushes-per-day, active window, tone) are collected via the `/start` conversation flow and stored in SQLite — they are **not** environment variables.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ systemctl restart gemma-rpi-agent
 | Variable | Required | Default |
 |---|---|---|
 | `TELEGRAM_TOKEN` | Yes | — |
-| `SYSTEM_PROMPT` | No | `"You are a helpful assistant running on a Raspberry Pi."` |
+| `SYSTEM_PROMPT` | No | `"You are a friendly English tutor chatting casually with a learner. Use natural, everyday English. If they ask about grammar, vocabulary, or usage, explain briefly with a small example."` |
 | `ALLOWED_USER_IDS` | No | empty (allow all) |
 
 Per-chat scheduling settings (timezone, pushes/day, active window, tone) are collected via the `/start` flow and stored in SQLite at `data/vocab.db` — not via env vars.

--- a/bot.py
+++ b/bot.py
@@ -49,7 +49,10 @@ load_dotenv()
 
 TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
 SYSTEM_PROMPT = os.getenv(
-    "SYSTEM_PROMPT", "You are a helpful assistant running on a Raspberry Pi."
+    "SYSTEM_PROMPT",
+    "You are a friendly English tutor chatting casually with a learner. "
+    "Use natural, everyday English. If they ask about grammar, vocabulary, "
+    "or usage, explain briefly with a small example.",
 )
 # Comma- or whitespace-separated Telegram user IDs allowed to talk to the bot.
 # Empty/unset means no restriction (all users allowed).


### PR DESCRIPTION
## Summary
- Replace the generic *"helpful assistant running on a Raspberry Pi"* default with a friendly English-tutor persona, so the just-talk flow stays on-theme with the vocab agent.
- Update `.env.example`, `CLAUDE.md`, and `README.md` so the documented default matches code.

Only affects the **default** when `SYSTEM_PROMPT` is unset; existing deployments with a custom `SYSTEM_PROMPT` are unchanged.

## Test plan
- [x] `python -m py_compile bot.py`
- [x] `pytest -q` (82 passed)
- [ ] After deploy, send a plain message and confirm the reply has a tutor flavor