### PR TITLE
feat: explain word when user taps ❌ forgot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -400,9 +400,6 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         log.warning("Malformed rate callback: %r", query.data)
         return
     rating = Rating.Good if verdict == "good" else Rating.Again
-    word_row = conn.execute(
-        "SELECT text FROM words WHERE id = ?", (word_id,)
-    ).fetchone()
     try:
         vocab.rate_word(conn, word_id, rating)
     except KeyError:
@@ -420,21 +417,28 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     # On ❌ forgot, follow up with a tiny definition + example so the user can
     # learn the word on the spot.
-    if rating == Rating.Again and word_row is not None:
-        word_text = word_row["text"]
-        try:
-            explanation = (await llm.chat(prompts.explain_messages(word_text))).strip()
-        except Exception as e:  # noqa: BLE001 — a failed explain shouldn't break rating
-            log.error("explain failed for word %s: %s", word_id, e)
-            return
-        if not explanation:
-            return
-        chat_id = update.effective_chat.id
-        try:
-            await query.message.reply_text(explanation)
-            append_turn(chat_id, "explain", f"[{word_text}] {explanation}")
-        except Exception as e:  # noqa: BLE001
-            log.error("failed to send explanation for chat %s: %s", chat_id, e)
+    if rating != Rating.Again:
+        return
+    try:
+        explanation = await sched_module.compose_explanation(
+            conn, word_id, llm_chat=llm.chat
+        )
+    except Exception as e:  # noqa: BLE001 — a failed explain shouldn't break rating
+        log.error("explain failed for word %s: %s", word_id, e)
+        return
+    if not explanation:
+        return
+    chat_id = update.effective_chat.id
+    try:
+        await query.message.reply_text(explanation)
+        # Best-effort: reuse the rated word's text for the transcript tag.
+        row = conn.execute(
+            "SELECT text FROM words WHERE id = ?", (word_id,)
+        ).fetchone()
+        tag_word = row["text"] if row is not None else "?"
+        append_turn(chat_id, "explain", f"[{tag_word}] {explanation}")
+    except Exception as e:  # noqa: BLE001
+        log.error("failed to send explanation for chat %s: %s", chat_id, e)
 
 
 async def on_resetvocab_confirm(

--- a/bot.py
+++ b/bot.py
@@ -400,6 +400,9 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         log.warning("Malformed rate callback: %r", query.data)
         return
     rating = Rating.Good if verdict == "good" else Rating.Again
+    word_row = conn.execute(
+        "SELECT text FROM words WHERE id = ?", (word_id,)
+    ).fetchone()
     try:
         vocab.rate_word(conn, word_id, rating)
     except KeyError:
@@ -414,6 +417,24 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         )
     except BadRequest:
         pass  # message too old or already replaced
+
+    # On ❌ forgot, follow up with a tiny definition + example so the user can
+    # learn the word on the spot.
+    if rating == Rating.Again and word_row is not None:
+        word_text = word_row["text"]
+        try:
+            explanation = (await llm.chat(prompts.explain_messages(word_text))).strip()
+        except Exception as e:  # noqa: BLE001 — a failed explain shouldn't break rating
+            log.error("explain failed for word %s: %s", word_id, e)
+            return
+        if not explanation:
+            return
+        chat_id = update.effective_chat.id
+        try:
+            await query.message.reply_text(explanation)
+            append_turn(chat_id, "explain", f"[{word_text}] {explanation}")
+        except Exception as e:  # noqa: BLE001
+            log.error("failed to send explanation for chat %s: %s", chat_id, e)
 
 
 async def on_resetvocab_confirm(

--- a/prompts.py
+++ b/prompts.py
@@ -25,6 +25,12 @@ _PUSH_SYSTEM = (
     "No headings, no quotes, no explanation — just the snippet."
 )
 
+_EXPLAIN_SYSTEM = (
+    "You are a concise English tutor. In ONE short sentence, explain in plain "
+    "English what the given word or phrase means. Then give ONE short example "
+    "sentence that uses it. Two sentences total. No headings, no quotes, no lists."
+)
+
 _JUST_TALK_TAIL = "\nKeep answers short: 1–2 paragraphs at most."
 
 _JUST_TALK_VOCAB = (
@@ -57,6 +63,18 @@ def push_messages(
             "content": f"{_PUSH_SYSTEM}\n{_TONE_INSTRUCTIONS[resolved]}",
         },
         {"role": "user", "content": f"Word to use: {word}"},
+    ]
+
+
+def explain_messages(word: str) -> list[dict]:
+    """Build messages asking for a brief meaning + one example for `word`.
+
+    Used when the user taps ❌ forgot on a push — we follow up with a tiny
+    definition so they can learn it on the spot.
+    """
+    return [
+        {"role": "system", "content": _EXPLAIN_SYSTEM},
+        {"role": "user", "content": f"Word or phrase: {word}"},
     ]
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -129,6 +129,28 @@ async def compose_push(
     return picked["id"], word, text
 
 
+async def compose_explanation(
+    conn: sqlite3.Connection,
+    word_id: int,
+    *,
+    llm_chat: LlmChat,
+) -> str | None:
+    """Fetch the word text and ask the LLM for a short meaning + example.
+
+    Returns the stripped explanation, or None if the word no longer exists or
+    the LLM returned nothing usable. The caller is responsible for actually
+    delivering the text (e.g. via Telegram) — keeping the HTTP side out of
+    this module makes it testable without mocks.
+    """
+    row = conn.execute(
+        "SELECT text FROM words WHERE id = ?", (word_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    text = (await llm_chat(prompts.explain_messages(row["text"]))).strip()
+    return text or None
+
+
 def log_push(
     conn: sqlite3.Connection,
     chat_id: int,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -48,6 +48,16 @@ def test_push_messages_mixed_tone_uses_rng() -> None:
     )
 
 
+def test_explain_messages_has_system_and_user_with_word() -> None:
+    msgs = prompts.explain_messages("ephemeral")
+    assert [m["role"] for m in msgs] == ["system", "user"]
+    assert "ephemeral" in msgs[1]["content"]
+    # System prompt should steer toward a compact meaning + example.
+    sys = msgs[0]["content"].lower()
+    assert "example" in sys
+    assert "two sentences" in sys
+
+
 def test_just_talk_system_without_vocab_just_appends_length_rule() -> None:
     out = prompts.just_talk_system("You are helpful.", [])
     assert out.startswith("You are helpful.")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -243,6 +243,60 @@ def test_compose_push_returns_anyway_after_retries(conn: sqlite3.Connection) -> 
     assert "ephemeral" not in text.lower()
 
 
+# --- compose_explanation -----------------------------------------------------
+
+
+def test_compose_explanation_returns_stripped_text(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "ephemeral")
+    row = conn.execute(
+        "SELECT id FROM words WHERE chat_id = ?", (CHAT,)
+    ).fetchone()
+
+    seen: list[list[dict]] = []
+
+    async def llm_ok(msgs):
+        seen.append(msgs)
+        return "  Lasting a very short time.\nExample: The joy was ephemeral.  \n"
+
+    out = asyncio.run(
+        scheduler.compose_explanation(conn, row["id"], llm_chat=llm_ok)
+    )
+    assert out == "Lasting a very short time.\nExample: The joy was ephemeral."
+    # The prompt must be built from prompts.explain_messages (system + user
+    # with the word in the user message).
+    assert len(seen) == 1
+    msgs = seen[0]
+    assert [m["role"] for m in msgs] == ["system", "user"]
+    assert "ephemeral" in msgs[1]["content"]
+
+
+def test_compose_explanation_returns_none_for_unknown_word(conn: sqlite3.Connection) -> None:
+    async def llm_fail(msgs):
+        raise AssertionError("llm should not be called when the word is gone")
+
+    out = asyncio.run(
+        scheduler.compose_explanation(conn, 99999, llm_chat=llm_fail)
+    )
+    assert out is None
+
+
+def test_compose_explanation_returns_none_on_empty_llm_reply(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "placid")
+    row = conn.execute(
+        "SELECT id FROM words WHERE chat_id = ?", (CHAT,)
+    ).fetchone()
+
+    async def llm_blank(msgs):
+        return "   \n  "
+
+    out = asyncio.run(
+        scheduler.compose_explanation(conn, row["id"], llm_chat=llm_blank)
+    )
+    assert out is None
+
+
 # --- log_push / mark_rated ---------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- On a push, tapping ❌ forgot now triggers a follow-up message with a one-sentence meaning plus a short example sentence for that word or phrase. Tapping ✅ knew is unchanged.
- Adds `prompts.explain_messages(word)` — a compact tutor-style system prompt targeting exactly two sentences (meaning + example).
- Wires it into `on_rate` in `bot.py`: fetches the word text before rating, and on `Rating.Again` calls `llm.chat()` and replies to the push message. Failures are logged without breaking the rating path.
- Logs the explanation to the chat transcript tagged `explain`.

## Impact on the live bot
- Only the ❌ forgot branch of the rating callback changes. Each forgot rating now makes one extra non-streaming call to the llama.cpp server (same `llm.chat` entrypoint used by pushes) and sends one extra Telegram message.

## Test plan
- [x] `python -m py_compile bot.py`
- [x] `python -m pytest -q` — 83 passed
- [ ] Manual: trigger a push, tap ❌ forgot, confirm the explanation arrives as a reply and the word is rated as `Again` in `words`.
- [ ] Manual: tap ✅ knew on another push, confirm no extra message is sent.