### PR TITLE
feat: raise pushes/day range to 6–12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Per-chat scheduling settings (timezone, pushes-per-day, active window, tone) are
 
 | Command | Purpose |
 |---|---|
-| `/start` | Walks a guided config: timezone → pushes/day (1–8) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed). Overwrites previous settings; vocab is preserved. |
+| `/start` | Walks a guided config: timezone → pushes/day (6–12) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed). Overwrites previous settings; vocab is preserved. |
 | `/help` | Shows a getting-started intro and lists all commands with descriptions. |
 | `/clear` | Resets the chat history (LLM memory) for this chat. Vocab and settings untouched. |
 | `/add <word or phrase>` | Add a word to this chat's vocab. Normalized to lowercased+stripped form. |
@@ -64,7 +64,7 @@ Code is split into focused modules (entrypoint is `bot.py`):
 - **`llm.py`** — llama.cpp HTTP client. `stream_chat()` for live edits, `chat()` one-shot for pushes, `health()` for `/model`. SSE/completion parsing is factored into pure helpers.
 - **`vocab.py`** — vocabulary CRUD, literal mention scanning, FSRS rating (`rate_word`), and the weighted-random `select_word`. Uses `py-fsrs` with `desired_retention=0.95` and `maximum_interval=7d` so review intervals stay tight.
 - **`prompts.py`** — tone-flavoured push templates and the just-talk system-prompt composer that appends the chat's vocab as soft hints.
-- **`config_flow.py`** — `Settings` dataclass + `ConfigSession` state machine for `/start`; per-step validators (IANA tz, 1–8 pushes, HH:MM, known tone); `save_settings` / `load_settings` upsert against the `chats` table.
+- **`config_flow.py`** — `Settings` dataclass + `ConfigSession` state machine for `/start`; per-step validators (IANA tz, 6–12 pushes, HH:MM, known tone); `save_settings` / `load_settings` upsert against the `chats` table.
 - **`scheduler.py`** — `plan_push_times` (equal-bucket sampling with half-gap edge buffers), `compose_push` (select + LLM call + retry once if the word didn't appear literally), `log_push` / `mark_rated`, and `PushRunner` wrapping `AsyncIOScheduler` with per-chat daily re-planning at 00:01 local.
 - **`db.py`** — SQLite schema (`chats`, `words`, `push_log`) with FSRS columns on `words`; `connect()` sets WAL + `PRAGMA foreign_keys=ON`; `init_db()` applies forward-only column migrations.
 - **`tests/`** — pytest suite covering schema constraints, vocab CRUD, mention scanning, FSRS state transitions, selection-weight math, deterministic weighted sampling, prompt composition, tz/time validators, config session transitions, plan_push_times determinism + min-gap, compose_push retry paths, push_log roundtrip, PushRunner job registration.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Per-chat scheduling settings (timezone, pushes/day, active window, tone) are col
 
 | Command | Description |
 |---|---|
-| `/start` | Walks a guided config: timezone → pushes/day (1–8) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed). Re-running overwrites settings; vocab is preserved. |
+| `/start` | Walks a guided config: timezone → pushes/day (6–12) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed). Re-running overwrites settings; vocab is preserved. |
 | `/clear` | Resets the chat's LLM history. Vocab and settings untouched. |
 | `/add <word or phrase>` | Add a word to this chat's vocab. |
 | `/remove <word or phrase>` | Remove a word. |

--- a/bot.py
+++ b/bot.py
@@ -256,7 +256,7 @@ COMMANDS: list[tuple[str, str]] = [
 HELP_TEXT = (
     "🤖 *Gemma vocab agent*\n\n"
     "*Getting started*\n"
-    "1. Run /start and answer four questions: timezone, pushes per day (1–8), "
+    "1. Run /start and answer four questions: timezone, pushes per day (6–12), "
     "active window (HH:MM–HH:MM), tone.\n"
     "2. Add words with /add <word or phrase>. The bot sends short snippets "
     "using those words at random times inside your window.\n"

--- a/config_flow.py
+++ b/config_flow.py
@@ -14,8 +14,8 @@ from dataclasses import dataclass, asdict
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 TONES = ("funny", "motivational", "scary", "bright", "mixed")
-MIN_PUSHES = 1
-MAX_PUSHES = 8
+MIN_PUSHES = 6
+MAX_PUSHES = 12
 
 
 @dataclass

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,7 +28,9 @@ def test_validate_pushes_accepts_range() -> None:
 
 
 def test_validate_pushes_rejects_out_of_range() -> None:
-    for bad in ("0", "9", "-1", "lots"):
+    below = str(config_flow.MIN_PUSHES - 1)
+    above = str(config_flow.MAX_PUSHES + 1)
+    for bad in (below, above, "0", "-1", "lots"):
         with pytest.raises(ValueError):
             config_flow.validate_pushes(bad)
 
@@ -58,7 +60,7 @@ def test_validate_tone_rejects_unknown() -> None:
 
 
 def _walk_happy_path(session: config_flow.ConfigSession) -> None:
-    for reply in ("Europe/Warsaw", "3", "09:00", "21:00", "mixed"):
+    for reply in ("Europe/Warsaw", "7", "09:00", "21:00", "mixed"):
         advanced, _ = session.submit(reply)
         assert advanced is True
 
@@ -70,7 +72,7 @@ def test_session_completes_with_valid_replies() -> None:
     assert s.done is True
     settings = s.settings()
     assert settings.tz == "Europe/Warsaw"
-    assert settings.pushes_per_day == 3
+    assert settings.pushes_per_day == 7
     assert settings.active_start == "09:00"
     assert settings.active_end == "21:00"
     assert settings.tone == "mixed"


### PR DESCRIPTION
## Summary
- Raise the \`/start\` pushes-per-day range from 1–8 to 6–12 so users always get multiple pushes and the floor can't collapse to one.
- Updates \`config_flow.MIN_PUSHES\`/\`MAX_PUSHES\` (the prompt text and validator messages derive from these, so they track automatically).
- Syncs the range in \`CLAUDE.md\`, \`README.md\`, and \`/help\` text in \`bot.py\`.

## Impact on the live bot
- Existing chats already have \`pushes_per_day\` stored and keep working as-is; the new range only kicks in on the next \`/start\` run.
- At 12 pushes the 45-min min-gap needs a window ≥ 9h. Tighter windows still plan successfully — \`plan_push_times\` falls back to bucket centers when the gap constraint can't be met (covered by \`test_plan_degrades_gracefully_on_tight_window\`).

## Test plan
- [x] \`python -m py_compile bot.py\`
- [x] \`python -m pytest -q\` — 86 passed
- [ ] Manual: run \`/start\`, confirm the prompt says 6–12 and values like 5 or 13 are rejected.