### PR TITLE
feat: add /translate command (Google Translate, LLM-free)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,13 +43,14 @@ Per-chat scheduling settings (timezone, pushes-per-day, active window, tone) are
 
 | Command | Purpose |
 |---|---|
-| `/start` | Walks a guided config: timezone → pushes/day (6–12) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed). Overwrites previous settings; vocab is preserved. |
+| `/start` | Walks a guided config: timezone → pushes/day (6–12) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed) → target language (for `/translate`). Overwrites previous settings; vocab is preserved. |
 | `/help` | Shows a getting-started intro and lists all commands with descriptions. |
 | `/clear` | Resets the chat history (LLM memory) for this chat. Vocab and settings untouched. |
 | `/add <word or phrase>` | Add a word to this chat's vocab. Normalized to lowercased+stripped form. |
 | `/remove <word or phrase>` | Remove by exact (normalized) match. |
 | `/list [substring]` | List all vocab words (least-mentioned first), or only those matching a substring. |
 | `/resetvocab` | Wipes the chat's vocabulary (with a confirm button). |
+| `/translate <text>` | Google-translate the args (or, if sent as a reply, the replied message) into the chat's configured target language. Does **not** invoke the LLM. |
 | `/model` | Shows the llama.cpp endpoint and health status. |
 
 Plain (non-slash) messages go through the **just-talk** flow: the chat history is passed to the model with the current vocab list injected into the system prompt as soft hints. Any vocab words that appear literally in the reply bump `mention_count` and update `last_used_at`.
@@ -64,7 +65,8 @@ Code is split into focused modules (entrypoint is `bot.py`):
 - **`llm.py`** — llama.cpp HTTP client. `stream_chat()` for live edits, `chat()` one-shot for pushes, `health()` for `/model`. SSE/completion parsing is factored into pure helpers.
 - **`vocab.py`** — vocabulary CRUD, literal mention scanning, FSRS rating (`rate_word`), and the weighted-random `select_word`. Uses `py-fsrs` with `desired_retention=0.95` and `maximum_interval=7d` so review intervals stay tight.
 - **`prompts.py`** — tone-flavoured push templates and the just-talk system-prompt composer that appends the chat's vocab as soft hints.
-- **`config_flow.py`** — `Settings` dataclass + `ConfigSession` state machine for `/start`; per-step validators (IANA tz, 6–12 pushes, HH:MM, known tone); `save_settings` / `load_settings` upsert against the `chats` table.
+- **`config_flow.py`** — `Settings` dataclass + `ConfigSession` state machine for `/start`; per-step validators (IANA tz, 6–12 pushes, HH:MM, known tone, known target language via `translator.normalize_target`); `save_settings` / `load_settings` upsert against the `chats` table.
+- **`translator.py`** — thin wrapper around `deep_translator.GoogleTranslator` for `/translate`. `normalize_target` maps a name or ISO code to an ISO code (no network); `translate` does the Google call. Explicitly bypasses the LLM because Gemma's Russian translations are weak.
 - **`scheduler.py`** — `plan_push_times` (equal-bucket sampling with half-gap edge buffers), `compose_push` (select + LLM call + retry once if the word didn't appear literally), `log_push` / `mark_rated`, and `PushRunner` wrapping `AsyncIOScheduler` with per-chat daily re-planning at 00:01 local.
 - **`db.py`** — SQLite schema (`chats`, `words`, `push_log`) with FSRS columns on `words`; `connect()` sets WAL + `PRAGMA foreign_keys=ON`; `init_db()` applies forward-only column migrations.
 - **`tests/`** — pytest suite covering schema constraints, vocab CRUD, mention scanning, FSRS state transitions, selection-weight math, deterministic weighted sampling, prompt composition, tz/time validators, config session transitions, plan_push_times determinism + min-gap, compose_push retry paths, push_log roundtrip, PushRunner job registration.
@@ -85,7 +87,7 @@ Each factor lives in `[0, 1]`, lifted to `[1, 2]` so no single signal dominates.
 
 - Path: `data/vocab.db` (git-ignored). Created on first run.
 - Tables:
-  - `chats(chat_id PK, tz, pushes_per_day, active_start, active_end, tone, created_at)`
+  - `chats(chat_id PK, tz, pushes_per_day, active_start, active_end, tone, translate_target, created_at)`
   - `words(id PK, chat_id FK, text, added_at, mention_count, last_used_at, stability, difficulty, state, step, due, reps, lapses, last_review, UNIQUE(chat_id, text))`
   - `push_log(id PK, chat_id, sent_at, tg_message_id, word_ids_json, rated)`
 - Cascade-delete: removing a chat drops its words and push_log entries.

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ Per-chat scheduling settings (timezone, pushes/day, active window, tone) are col
 
 | Command | Description |
 |---|---|
-| `/start` | Walks a guided config: timezone → pushes/day (6–12) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed). Re-running overwrites settings; vocab is preserved. |
+| `/start` | Walks a guided config: timezone → pushes/day (6–12) → active window (HH:MM) → tone (funny/motivational/scary/bright/mixed) → target language for `/translate`. Re-running overwrites settings; vocab is preserved. |
 | `/clear` | Resets the chat's LLM history. Vocab and settings untouched. |
 | `/add <word or phrase>` | Add a word to this chat's vocab. |
 | `/remove <word or phrase>` | Remove a word. |
 | `/list [substring]` | List vocab (least-mentioned first), optionally filtered by substring. |
 | `/resetvocab` | Wipe the chat's vocabulary (with a confirm button). |
+| `/translate <text>` | Google-translate the args (or the replied message if sent as a reply) into your chat's target language. Runs outside the LLM. |
 | `/model` | Show the llama.cpp endpoint and health status. |
 
 Plain-text messages go to the chat model with your vocab injected into the system prompt as soft hints. Words that appear literally in the reply bump their mention count.

--- a/bot.py
+++ b/bot.py
@@ -43,6 +43,7 @@ import db as db_module
 import llm
 import prompts
 import scheduler as sched_module
+import translator
 import vocab
 
 load_dotenv()
@@ -243,12 +244,13 @@ async def dispatch_push(chat_id: int) -> None:
 
 # Single source of truth for commands — used by /help and set_my_commands.
 COMMANDS: list[tuple[str, str]] = [
-    ("start", "Configure schedule: timezone, pushes/day, active window, tone"),
+    ("start", "Configure schedule: timezone, pushes/day, active window, tone, target language"),
     ("help", "Show this help message"),
     ("add", "Add a word or phrase to this chat's vocab"),
     ("remove", "Remove a word or phrase from vocab"),
     ("list", "List vocab words (optionally filter by substring)"),
     ("resetvocab", "Wipe this chat's vocabulary (with confirm)"),
+    ("translate", "Translate args, or reply to a message with /translate"),
     ("clear", "Reset the chat history (LLM memory)"),
     ("model", "Show the llama.cpp endpoint and health"),
 ]
@@ -256,8 +258,8 @@ COMMANDS: list[tuple[str, str]] = [
 HELP_TEXT = (
     "🤖 *Gemma vocab agent*\n\n"
     "*Getting started*\n"
-    "1. Run /start and answer four questions: timezone, pushes per day (6–12), "
-    "active window (HH:MM–HH:MM), tone.\n"
+    "1. Run /start and answer five questions: timezone, pushes per day (6–12), "
+    "active window (HH:MM–HH:MM), tone, target language for /translate.\n"
     "2. Add words with /add <word or phrase>. The bot sends short snippets "
     "using those words at random times inside your window.\n"
     "3. Tap ✅ knew / ❌ forgot on each push — ratings drive FSRS spaced "
@@ -368,6 +370,45 @@ async def cmd_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if len(body) > MAX_MSG_LEN - len(header) - 32:
         body = body[: MAX_MSG_LEN - len(header) - 32] + "\n…"
     await update.message.reply_text(f"{header}\n{body}")
+
+
+async def cmd_translate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_allowed(update):
+        return
+    assert conn is not None
+    chat_id = update.effective_chat.id
+    settings = config_flow.load_settings(conn, chat_id)
+    if settings is None:
+        await update.message.reply_text(
+            "Run /start first so I know which language to translate into."
+        )
+        return
+
+    # Two input modes: explicit args, or a reply to another message.
+    args_text = " ".join(context.args or []).strip()
+    if args_text:
+        source_text = args_text
+    elif update.message.reply_to_message is not None:
+        replied = update.message.reply_to_message
+        source_text = (replied.text or replied.caption or "").strip()
+    else:
+        source_text = ""
+
+    if not source_text:
+        await update.message.reply_text(
+            "Usage: /translate <text>, or reply to a message with /translate."
+        )
+        return
+
+    try:
+        translated = await asyncio.to_thread(
+            translator.translate, source_text, settings.target_lang
+        )
+    except Exception as e:  # noqa: BLE001 — surface the reason to the user
+        log.error("translate failed for chat %s: %s", chat_id, e)
+        await update.message.reply_text(f"⚠️ Translation failed: {e}")
+        return
+    await update.message.reply_text(translated or "⚠️ Empty translation.")
 
 
 async def cmd_resetvocab(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -605,6 +646,7 @@ def main() -> None:
     app.add_handler(CommandHandler("remove", cmd_remove))
     app.add_handler(CommandHandler("list", cmd_list))
     app.add_handler(CommandHandler("resetvocab", cmd_resetvocab))
+    app.add_handler(CommandHandler("translate", cmd_translate))
 
     app.add_handler(CallbackQueryHandler(on_rate, pattern=r"^rate:"))
     app.add_handler(CallbackQueryHandler(on_resetvocab_confirm, pattern=r"^rv:"))

--- a/config_flow.py
+++ b/config_flow.py
@@ -13,6 +13,8 @@ import sqlite3
 from dataclasses import dataclass, asdict
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import translator
+
 TONES = ("funny", "motivational", "scary", "bright", "mixed")
 MIN_PUSHES = 6
 MAX_PUSHES = 12
@@ -25,6 +27,7 @@ class Settings:
     active_start: str  # "HH:MM"
     active_end: str
     tone: str
+    target_lang: str  # ISO 639-1 code used by /translate
 
 
 def validate_tz(s: str) -> str:
@@ -68,6 +71,10 @@ def validate_tone(s: str) -> str:
     return v
 
 
+def validate_target_lang(s: str) -> str:
+    return translator.normalize_target(s)
+
+
 # Step definitions: (field, prompt, validator).
 _STEPS = [
     ("tz", "What timezone? (e.g. Europe/Warsaw, UTC)", validate_tz),
@@ -90,6 +97,11 @@ _STEPS = [
         "tone",
         "Tone preference? (funny / motivational / scary / bright / mixed)",
         validate_tone,
+    ),
+    (
+        "target_lang",
+        "Translation target language? (e.g. 'russian' or 'ru' — used by /translate)",
+        validate_target_lang,
     ),
 ]
 
@@ -150,12 +162,14 @@ def save_settings(
     """Upsert the chat's configuration row."""
     now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     conn.execute(
-        "INSERT INTO chats(chat_id, tz, pushes_per_day, active_start, active_end, tone, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "INSERT INTO chats("
+        "chat_id, tz, pushes_per_day, active_start, active_end, tone, "
+        "translate_target, created_at"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(chat_id) DO UPDATE SET "
         "tz=excluded.tz, pushes_per_day=excluded.pushes_per_day, "
         "active_start=excluded.active_start, active_end=excluded.active_end, "
-        "tone=excluded.tone",
+        "tone=excluded.tone, translate_target=excluded.translate_target",
         (
             chat_id,
             settings.tz,
@@ -163,6 +177,7 @@ def save_settings(
             settings.active_start,
             settings.active_end,
             settings.tone,
+            settings.target_lang,
             now,
         ),
     )
@@ -172,7 +187,7 @@ def load_settings(
     conn: sqlite3.Connection, chat_id: int
 ) -> Settings | None:
     row = conn.execute(
-        "SELECT tz, pushes_per_day, active_start, active_end, tone "
+        "SELECT tz, pushes_per_day, active_start, active_end, tone, translate_target "
         "FROM chats WHERE chat_id = ?",
         (chat_id,),
     ).fetchone()
@@ -184,6 +199,7 @@ def load_settings(
         active_start=row["active_start"],
         active_end=row["active_end"],
         tone=row["tone"],
+        target_lang=row["translate_target"],
     )
 
 

--- a/db.py
+++ b/db.py
@@ -14,13 +14,14 @@ DEFAULT_DB_PATH = Path(__file__).resolve().parent / "data" / "vocab.db"
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS chats (
-    chat_id        INTEGER PRIMARY KEY,
-    tz             TEXT    NOT NULL,
-    pushes_per_day INTEGER NOT NULL DEFAULT 3,
-    active_start   TEXT    NOT NULL DEFAULT '09:00',
-    active_end     TEXT    NOT NULL DEFAULT '21:00',
-    tone           TEXT    NOT NULL DEFAULT 'mixed',
-    created_at     TEXT    NOT NULL
+    chat_id          INTEGER PRIMARY KEY,
+    tz               TEXT    NOT NULL,
+    pushes_per_day   INTEGER NOT NULL DEFAULT 3,
+    active_start     TEXT    NOT NULL DEFAULT '09:00',
+    active_end       TEXT    NOT NULL DEFAULT '21:00',
+    tone             TEXT    NOT NULL DEFAULT 'mixed',
+    translate_target TEXT    NOT NULL DEFAULT 'ru',
+    created_at       TEXT    NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS words (
@@ -80,3 +81,8 @@ def init_db(conn: sqlite3.Connection) -> None:
     conn.executescript(SCHEMA)
     if "step" not in _column_names(conn, "words"):
         conn.execute("ALTER TABLE words ADD COLUMN step INTEGER")
+    if "translate_target" not in _column_names(conn, "chats"):
+        # Existing chats get 'ru' so /translate works before they re-run /start.
+        conn.execute(
+            "ALTER TABLE chats ADD COLUMN translate_target TEXT NOT NULL DEFAULT 'ru'"
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx>=0.27.0
 python-dotenv>=1.0.0
 fsrs>=6.3
 APScheduler>=3.10
+deep-translator>=1.11

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -60,7 +60,7 @@ def test_validate_tone_rejects_unknown() -> None:
 
 
 def _walk_happy_path(session: config_flow.ConfigSession) -> None:
-    for reply in ("Europe/Warsaw", "7", "09:00", "21:00", "mixed"):
+    for reply in ("Europe/Warsaw", "7", "09:00", "21:00", "mixed", "russian"):
         advanced, _ = session.submit(reply)
         assert advanced is True
 
@@ -76,6 +76,17 @@ def test_session_completes_with_valid_replies() -> None:
     assert settings.active_start == "09:00"
     assert settings.active_end == "21:00"
     assert settings.tone == "mixed"
+    assert settings.target_lang == "ru"
+
+
+def test_validate_target_lang_accepts_code_and_name() -> None:
+    assert config_flow.validate_target_lang("ru") == "ru"
+    assert config_flow.validate_target_lang("Russian") == "ru"
+
+
+def test_validate_target_lang_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        config_flow.validate_target_lang("klingon")
 
 
 def test_session_stays_on_step_on_invalid_input() -> None:
@@ -115,6 +126,7 @@ def test_save_and_load_settings_roundtrip(conn: sqlite3.Connection) -> None:
         active_start="08:00",
         active_end="22:00",
         tone="funny",
+        target_lang="ru",
     )
     config_flow.save_settings(conn, 123, s)
     loaded = config_flow.load_settings(conn, 123)
@@ -122,8 +134,8 @@ def test_save_and_load_settings_roundtrip(conn: sqlite3.Connection) -> None:
 
 
 def test_save_settings_upserts(conn: sqlite3.Connection) -> None:
-    first = config_flow.Settings("UTC", 3, "09:00", "21:00", "mixed")
-    second = config_flow.Settings("Europe/Warsaw", 5, "08:30", "23:00", "scary")
+    first = config_flow.Settings("UTC", 3, "09:00", "21:00", "mixed", "ru")
+    second = config_flow.Settings("Europe/Warsaw", 5, "08:30", "23:00", "scary", "es")
     config_flow.save_settings(conn, 1, first)
     config_flow.save_settings(conn, 1, second)
     loaded = config_flow.load_settings(conn, 1)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -152,7 +152,7 @@ def _seed_chat(conn: sqlite3.Connection, tone: str = "funny") -> None:
     config_flow.save_settings(
         conn,
         CHAT,
-        config_flow.Settings("UTC", 2, "09:00", "21:00", tone),
+        config_flow.Settings("UTC", 2, "09:00", "21:00", tone, "ru"),
     )
 
 
@@ -336,7 +336,7 @@ def runner(conn: sqlite3.Connection):
 def test_schedule_chat_adds_plan_and_push_jobs(
     runner: scheduler.PushRunner, conn: sqlite3.Connection
 ) -> None:
-    settings = config_flow.Settings("UTC", 3, "09:00", "21:00", "mixed")
+    settings = config_flow.Settings("UTC", 3, "09:00", "21:00", "mixed", "ru")
     config_flow.save_settings(conn, CHAT, settings)
     runner.schedule_chat(CHAT, settings)
     ids = {j.id for j in runner.scheduler.get_jobs()}
@@ -351,7 +351,7 @@ def test_schedule_chat_adds_plan_and_push_jobs(
 def test_schedule_chat_is_idempotent(
     runner: scheduler.PushRunner, conn: sqlite3.Connection
 ) -> None:
-    settings = config_flow.Settings("UTC", 2, "00:00", "23:59", "mixed")
+    settings = config_flow.Settings("UTC", 2, "00:00", "23:59", "mixed", "ru")
     config_flow.save_settings(conn, CHAT, settings)
     runner.schedule_chat(CHAT, settings)
     first = {j.id for j in runner.scheduler.get_jobs()}

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,36 @@
+"""Tests for translator.normalize_target.
+
+`translate` itself hits Google; we don't cover it here — bot.py treats the
+library as a black box and catches failures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import translator
+
+
+def test_normalize_target_accepts_iso_code() -> None:
+    assert translator.normalize_target("ru") == "ru"
+    assert translator.normalize_target("EN") == "en"
+
+
+def test_normalize_target_accepts_english_name() -> None:
+    assert translator.normalize_target("russian") == "ru"
+    assert translator.normalize_target("Russian") == "ru"
+    assert translator.normalize_target("  SPANISH  ") == "es"
+
+
+def test_normalize_target_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        translator.normalize_target("")
+    with pytest.raises(ValueError):
+        translator.normalize_target("   ")
+
+
+def test_normalize_target_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        translator.normalize_target("klingon")
+    with pytest.raises(ValueError):
+        translator.normalize_target("zz")

--- a/translator.py
+++ b/translator.py
@@ -1,0 +1,55 @@
+"""Google Translate wrapper via deep-translator.
+
+Kept thin and dependency-injectable so the rest of the code can stay out of
+HTTP-client territory and tests can substitute a fake `translate_fn`.
+Translation is intentionally offloaded to Google — Gemma's quality on short
+dictionary-style translations (especially into Russian) is not good enough,
+and this command should feel instantaneous.
+
+Only two primitives are exposed:
+
+  * `normalize_target(s)` — accept a language code ('ru') or English name
+    ('russian'); return the ISO 639-1 code. Pure, no network.
+  * `translate(text, target)` — call Google Translate via `deep_translator`.
+    Network call; wrap in `asyncio.to_thread` from async contexts.
+
+`_name_to_code()` is cached because `deep_translator`'s language list is a
+static dict (no network), so we only build it once per process.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _name_to_code() -> dict[str, str]:
+    """Return {'english': 'en', 'russian': 'ru', …} — the full supported map."""
+    from deep_translator import GoogleTranslator
+
+    return GoogleTranslator().get_supported_languages(as_dict=True)
+
+
+def normalize_target(s: str) -> str:
+    """Return the ISO code for a language given as a name or code.
+
+    Case-insensitive. Raises ValueError on empty input or unknown language.
+    """
+    raw = s.strip().lower()
+    if not raw:
+        raise ValueError("Language cannot be empty.")
+    mapping = _name_to_code()
+    if raw in mapping:  # full name, e.g. "russian"
+        return mapping[raw]
+    if raw in mapping.values():  # already an ISO code, e.g. "ru"
+        return raw
+    raise ValueError(
+        f"Unknown language {raw!r}. Try a code like 'ru' or a name like 'russian'."
+    )
+
+
+def translate(text: str, target: str) -> str:
+    """Google-translate `text` into `target` (ISO 639-1). Source auto-detected."""
+    from deep_translator import GoogleTranslator
+
+    return GoogleTranslator(source="auto", target=target).translate(text)


### PR DESCRIPTION
## Summary
- New \`/translate\` command with two input modes:
  - \`/translate <text>\` — translate the args.
  - Reply to a message with \`/translate\` — translate that message (also handles captioned messages).
- Translation runs through \`deep_translator.GoogleTranslator(source='auto', target=…)\` — the local Gemma model is **not** invoked. Gemma's Russian output was weak; Google's is reliable.
- New \`translator.py\`: \`normalize_target\` (name or ISO code → code, no network) and \`translate\` (the Google call).
- \`/start\` grows a sixth step (target language). Validator accepts \`"russian"\` or \`"ru"\` and stores the ISO code.
- Forward-only DB migration adds \`chats.translate_target TEXT NOT NULL DEFAULT 'ru'\` so existing chats already work without re-running \`/start\`.

## Impact on the live bot
- New dependency: \`deep-translator>=1.11\` (already installs clean on the Pi venv).
- First startup after merge will apply the \`ALTER TABLE\` migration — idempotent, safe to rerun.
- Existing chats keep working with the default \`ru\` target; to change it, re-run \`/start\`.
- \`cmd_translate\` runs the (synchronous) library call via \`asyncio.to_thread\` so it doesn't block the event loop.

## Test plan
- [x] \`python -m py_compile bot.py translator.py config_flow.py db.py\`
- [x] \`python -m pytest -q\` — 92 passed (was 86)
- [x] Live smoke: \`translator.translate('hilarious', 'ru')\` → \`веселый\`
- [x] Migration smoke: opening the live DB and calling \`init_db\` adds \`translate_target\` with default \`'ru'\` on the existing chats row.
- [ ] Manual on Telegram after deploy:
  - [ ] \`/translate hilarious\` → Russian word.
  - [ ] Reply to any message with \`/translate\` → translates that message.
  - [ ] \`/translate\` with nothing → usage hint.
  - [ ] Re-run \`/start\`, confirm sixth step and that entering \`klingon\` is rejected.