### PR TITLE
fix: quote the /translate command in replies

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -380,7 +380,8 @@ async def cmd_translate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     settings = config_flow.load_settings(conn, chat_id)
     if settings is None:
         await update.message.reply_text(
-            "Run /start first so I know which language to translate into."
+            "Run /start first so I know which language to translate into.",
+            do_quote=True,
         )
         return
 
@@ -396,7 +397,8 @@ async def cmd_translate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
     if not source_text:
         await update.message.reply_text(
-            "Usage: /translate <text>, or reply to a message with /translate."
+            "Usage: /translate <text>, or reply to a message with /translate.",
+            do_quote=True,
         )
         return
 
@@ -406,9 +408,13 @@ async def cmd_translate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         )
     except Exception as e:  # noqa: BLE001 — surface the reason to the user
         log.error("translate failed for chat %s: %s", chat_id, e)
-        await update.message.reply_text(f"⚠️ Translation failed: {e}")
+        await update.message.reply_text(
+            f"⚠️ Translation failed: {e}", do_quote=True
+        )
         return
-    await update.message.reply_text(translated or "⚠️ Empty translation.")
+    await update.message.reply_text(
+        translated or "⚠️ Empty translation.", do_quote=True
+    )
 
 
 async def cmd_resetvocab(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- \`cmd_translate\` now uses \`do_quote=True\` on all three reply paths (translated text, error, usage / \"run /start first\" hints) so the response arrives as a proper Telegram reply to the \`/translate\` message. This makes it easy to match translations to the commands that produced them, and is especially useful in reply-mode where otherwise two messages could look visually ambiguous.

## Impact on the live bot
- Behavior-only change on a single handler. No schema, env, or deps touched.
- Relies on \`do_quote=True\` which is the PTB 22.x preferred API (installed: \`python-telegram-bot==22.7\`).

## Test plan
- [x] \`python -m py_compile bot.py\`
- [x] \`python -m pytest -q\` — 92 passed (one flaky APScheduler test, unrelated, passes on retry)
- [ ] Manual: \`/translate hilarious\` — response should arrive as a reply quoting the \`/translate\` line.
- [ ] Manual: reply to another message with \`/translate\` — translation should quote the \`/translate\` command (not the original message).