### PR TITLE
fix: remove load/temp footer from free-mode replies

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -151,16 +151,6 @@ def is_allowed(update: Update) -> bool:
     return True
 
 
-def sys_footer() -> str:
-    load1, load5, load15 = os.getloadavg()
-    try:
-        temp_mc = int(open("/sys/class/thermal/thermal_zone0/temp").read())
-        temp_str = f"{temp_mc / 1000:.1f}°C"
-    except OSError:
-        temp_str = "n/a"
-    return f"\n\n`load {load1:.2f} {load5:.2f} {load15:.2f} | {temp_str}`"
-
-
 # --- telegram send helpers --------------------------------------------------
 
 
@@ -584,13 +574,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await safe_edit(current_msg, current_page or f"⚠️ Error: {e}")
         return
 
-    footer = sys_footer()
     final_text = current_page or "⚠️ No response from model."
-    if len(final_text) + len(footer) > MAX_MSG_LEN:
-        await safe_edit(current_msg, final_text)
-        await safe_send(context.bot, chat_id, footer.lstrip())
-    else:
-        await safe_edit(current_msg, final_text + footer)
+    await safe_edit(current_msg, final_text)
 
     histories[chat_id].append({"role": "assistant", "content": accumulated})
     append_turn(chat_id, "assistant", accumulated)


### PR DESCRIPTION
## Summary
- Drops the `sys_footer()` helper and its caller in the streaming just-talk path.
- Free-mode replies no longer carry a trailing \`load X | temp Y\` line.

## Why
User reported the host diagnostics footer (load average + CPU temp) showing up on every plain chat reply — it was leftover debug output, not user-facing info.

## Impact on live bot
Touches `bot.py` handler logic: the message sent after streaming completes no longer has a footer appended and the "footer overflow → second message" branch is gone. No change to push messages, commands, or scheduler.

## Test plan
- [x] \`python -m py_compile bot.py\`
- [x] \`python -m pytest -q\` — 92 passed
- [ ] Smoke-test on the Pi: send a plain message, confirm no footer