### PR TITLE
feat: replace /model with /status (host info + vocab count + bench)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Per-chat scheduling settings (timezone, pushes-per-day, active window, tone) are
 | `/list [substring]` | List all vocab words (least-mentioned first), or only those matching a substring. |
 | `/resetvocab` | Wipes the chat's vocabulary (with a confirm button). |
 | `/translate <text>` | Google-translate the args (or, if sent as a reply, the replied message) into the chat's configured target language. Does **not** invoke the LLM. |
-| `/model` | Shows the llama.cpp endpoint and health status. |
+| `/status` | Host diagnostics (hardware, OS, load, temp, disk free), vocab count for the chat, llama.cpp endpoint/health, and a short model bench (chars + tok/s, `model not responding` on 30 s timeout). |
 
 Plain (non-slash) messages go through the **just-talk** flow: the chat history is passed to the model with the current vocab list injected into the system prompt as soft hints. Any vocab words that appear literally in the reply bump `mention_count` and update `last_used_at`.
 
@@ -62,7 +62,8 @@ Scheduled **pushes** send 1 short snippet using 1 vocab word at a time, in the c
 Code is split into focused modules (entrypoint is `bot.py`):
 
 - **`bot.py`** — python-telegram-bot wiring. Command/callback/message handlers, scheduler bootstrap, transcript/history management, DB connection lifecycle.
-- **`llm.py`** — llama.cpp HTTP client. `stream_chat()` for live edits, `chat()` one-shot for pushes, `health()` for `/model`. SSE/completion parsing is factored into pure helpers.
+- **`llm.py`** — llama.cpp HTTP client. `stream_chat()` for live edits, `chat()` one-shot for pushes, `health()` and `bench()` for `/status`. SSE/completion parsing is factored into pure helpers.
+- **`sysinfo.py`** — pure readers for host diagnostics used by `/status` (hardware, OS, load, temp, disk free). Each reader has an injectable dependency and a safe fallback so /status works off-Pi too.
 - **`vocab.py`** — vocabulary CRUD, literal mention scanning, FSRS rating (`rate_word`), and the weighted-random `select_word`. Uses `py-fsrs` with `desired_retention=0.95` and `maximum_interval=7d` so review intervals stay tight.
 - **`prompts.py`** — tone-flavoured push templates and the just-talk system-prompt composer that appends the chat's vocab as soft hints.
 - **`config_flow.py`** — `Settings` dataclass + `ConfigSession` state machine for `/start`; per-step validators (IANA tz, 6–12 pushes, HH:MM, known tone, known target language via `translator.normalize_target`); `save_settings` / `load_settings` upsert against the `chats` table.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Per-chat scheduling settings (timezone, pushes/day, active window, tone) are col
 | `/list [substring]` | List vocab (least-mentioned first), optionally filtered by substring. |
 | `/resetvocab` | Wipe the chat's vocabulary (with a confirm button). |
 | `/translate <text>` | Google-translate the args (or the replied message if sent as a reply) into your chat's target language. Runs outside the LLM. |
-| `/model` | Show the llama.cpp endpoint and health status. |
+| `/status` | Show host diagnostics (hardware, OS, load, temp, disk free), vocab count, llama.cpp endpoint/health, and a short model bench. |
 
 Plain-text messages go to the chat model with your vocab injected into the system prompt as soft hints. Words that appear literally in the reply bump their mention count.
 

--- a/bot.py
+++ b/bot.py
@@ -43,6 +43,7 @@ import db as db_module
 import llm
 import prompts
 import scheduler as sched_module
+import sysinfo
 import translator
 import vocab
 
@@ -242,7 +243,7 @@ COMMANDS: list[tuple[str, str]] = [
     ("resetvocab", "Wipe this chat's vocabulary (with confirm)"),
     ("translate", "Translate args, or reply to a message with /translate"),
     ("clear", "Reset the chat history (LLM memory)"),
-    ("model", "Show the llama.cpp endpoint and health"),
+    ("status", "Show host diagnostics, vocab count, and a short model bench"),
 ]
 
 HELP_TEXT = (
@@ -285,14 +286,36 @@ async def cmd_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text("Conversation cleared.")
 
 
-async def cmd_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not is_allowed(update):
         return
-    status = await llm.health()
+    assert conn is not None
+    chat_id = update.effective_chat.id
+
+    hardware = sysinfo.read_hardware()
+    os_name = sysinfo.read_os_release()
+    load1, load5, load15 = sysinfo.read_loadavg()
+    temp = sysinfo.read_temperature()
+    free, total = sysinfo.read_disk_free("/")
+    words = vocab.count_words(conn, chat_id)
+    server = await llm.health()
+    bench_line = await llm.bench()
+
     await update.message.reply_text(
-        f"Model: {llm.MODEL}\n"
-        f"Endpoint: {llm.LLAMA_URL}\n"
-        f"Server status: {status}"
+        "System\n"
+        f"  Hardware: {hardware}\n"
+        f"  OS: {os_name}\n"
+        f"  Load: {load1:.2f} {load5:.2f} {load15:.2f}\n"
+        f"  Temp: {temp}\n"
+        f"  Disk /: {sysinfo.format_bytes(free)} free / "
+        f"{sysinfo.format_bytes(total)}\n"
+        f"  Vocab: {words} words\n"
+        "\n"
+        "Model\n"
+        f"  Name: {llm.MODEL}\n"
+        f"  Endpoint: {llm.LLAMA_URL}\n"
+        f"  Server: {server}\n"
+        f"  Bench: {bench_line}"
     )
 
 
@@ -632,7 +655,7 @@ def main() -> None:
     app.add_handler(CommandHandler("start", cmd_start))
     app.add_handler(CommandHandler("help", cmd_help))
     app.add_handler(CommandHandler("clear", cmd_clear))
-    app.add_handler(CommandHandler("model", cmd_model))
+    app.add_handler(CommandHandler("status", cmd_status))
     app.add_handler(CommandHandler("add", cmd_add))
     app.add_handler(CommandHandler("remove", cmd_remove))
     app.add_handler(CommandHandler("list", cmd_list))

--- a/llm.py
+++ b/llm.py
@@ -13,8 +13,10 @@ they can be unit-tested without standing up an HTTP mock.
 
 from __future__ import annotations
 
+import asyncio
 import json
-from typing import AsyncIterator
+import time
+from typing import AsyncIterator, Awaitable, Callable
 
 import httpx
 
@@ -101,3 +103,36 @@ async def health() -> str:
             return r.json().get("status", "unknown")
     except Exception as e:  # noqa: BLE001 — surface the reason verbatim to the user
         return f"unreachable ({e})"
+
+
+_BENCH_PROMPT = [{"role": "user", "content": "Reply with one short sentence."}]
+
+
+async def bench(
+    *,
+    chat_fn: Callable[..., Awaitable[str]] | None = None,
+    timeout: float = 30.0,
+    now: Callable[[], float] = time.monotonic,
+) -> str:
+    """Run a tiny prompt through the model and return a one-line perf summary.
+
+    On timeout returns ``"model not responding"``; on other errors returns a
+    short ``"error: <ExceptionType>"`` string. Injected collaborators keep this
+    unit-testable without an HTTP server.
+    """
+    if chat_fn is None:
+        chat_fn = chat
+    t0 = now()
+    try:
+        text = await asyncio.wait_for(
+            chat_fn(_BENCH_PROMPT, max_tokens=32, temperature=0.2),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        return "model not responding"
+    except Exception as e:  # noqa: BLE001 — surface the class name to the user
+        return f"error: {type(e).__name__}"
+    elapsed = now() - t0
+    chars = len(text)
+    tok_per_s = (chars / 4) / elapsed if elapsed > 0 else 0.0
+    return f"{chars} chars in {elapsed:.1f}s (~{tok_per_s:.1f} tok/s)"

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -1,0 +1,69 @@
+"""Host diagnostics for the /status command.
+
+Each reader is a pure helper with injectable dependencies so tests can supply
+fakes without monkeypatching, and with defensive fallbacks because /status
+should never crash just because a sysfs file is missing off-Pi.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+from typing import Callable
+
+
+def read_hardware(path: str = "/proc/device-tree/model") -> str:
+    """Return a human string for the host device (e.g. 'Raspberry Pi 4 ...')."""
+    try:
+        with open(path, "rb") as f:
+            raw = f.read().rstrip(b"\x00")
+        return raw.decode("utf-8", errors="replace").strip() or platform.machine() or "unknown"
+    except OSError:
+        return platform.machine() or "unknown"
+
+
+def read_os_release(path: str = "/etc/os-release") -> str:
+    """Return PRETTY_NAME from os-release, else a platform.platform() fallback."""
+    try:
+        with open(path) as f:
+            for line in f:
+                if line.startswith("PRETTY_NAME="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return platform.platform()
+
+
+def read_temperature(path: str = "/sys/class/thermal/thermal_zone0/temp") -> str:
+    try:
+        with open(path) as f:
+            return f"{int(f.read().strip()) / 1000:.1f}°C"
+    except (OSError, ValueError):
+        return "n/a"
+
+
+def read_loadavg(
+    getloadavg: Callable[[], tuple[float, float, float]] = os.getloadavg,
+) -> tuple[float, float, float]:
+    try:
+        return getloadavg()
+    except OSError:
+        return (0.0, 0.0, 0.0)
+
+
+def read_disk_free(
+    path: str = "/",
+    disk_usage: Callable[[str], shutil._ntuple_diskusage] = shutil.disk_usage,
+) -> tuple[int, int]:
+    """Return (free_bytes, total_bytes) for the filesystem at `path`."""
+    du = disk_usage(path)
+    return du.free, du.total
+
+
+def format_bytes(n: float) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(n) < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PB"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,8 @@
-"""Tests for llm.py parse helpers (no network)."""
+"""Tests for llm.py parse helpers and bench (no network)."""
 
 from __future__ import annotations
+
+import asyncio
 
 import llm
 
@@ -38,3 +40,31 @@ def test_parse_completion_returns_content() -> None:
 def test_parse_completion_missing_content_returns_empty() -> None:
     payload = {"choices": [{"message": {}}]}
     assert llm._parse_completion(payload) == ""
+
+
+def test_bench_formats_chars_elapsed_and_rate() -> None:
+    clock = iter([100.0, 102.0])  # 2 s elapsed
+
+    async def fake_chat(messages, **kw):
+        assert kw.get("max_tokens") == 32
+        return "x" * 40  # 40 chars ≈ 10 tokens → 5 tok/s
+
+    out = asyncio.run(llm.bench(chat_fn=fake_chat, now=lambda: next(clock)))
+    assert out == "40 chars in 2.0s (~5.0 tok/s)"
+
+
+def test_bench_timeout_returns_model_not_responding() -> None:
+    async def hangs(messages, **kw):
+        await asyncio.sleep(10)
+        return "unreachable"
+
+    out = asyncio.run(llm.bench(chat_fn=hangs, timeout=0.05))
+    assert out == "model not responding"
+
+
+def test_bench_error_reports_exception_type() -> None:
+    async def boom(messages, **kw):
+        raise ConnectionError("nope")
+
+    out = asyncio.run(llm.bench(chat_fn=boom))
+    assert out == "error: ConnectionError"

--- a/tests/test_sysinfo.py
+++ b/tests/test_sysinfo.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections import namedtuple
+
+import sysinfo
+
+
+_DiskUsage = namedtuple("_DiskUsage", "total used free")
+
+
+def test_read_hardware_strips_nul(tmp_path):
+    p = tmp_path / "model"
+    p.write_bytes(b"Raspberry Pi 4 Model B Rev 1.4\x00")
+    assert sysinfo.read_hardware(str(p)) == "Raspberry Pi 4 Model B Rev 1.4"
+
+
+def test_read_hardware_missing_file_falls_back(tmp_path):
+    # Missing file → non-empty fallback from platform.machine() or "unknown".
+    missing = tmp_path / "nope"
+    result = sysinfo.read_hardware(str(missing))
+    assert result and isinstance(result, str)
+
+
+def test_read_os_release_extracts_pretty_name(tmp_path):
+    p = tmp_path / "os-release"
+    p.write_text(
+        'NAME="Raspberry Pi OS"\n'
+        'PRETTY_NAME="Raspberry Pi OS (bookworm)"\n'
+        "VERSION_ID=12\n"
+    )
+    assert sysinfo.read_os_release(str(p)) == "Raspberry Pi OS (bookworm)"
+
+
+def test_read_os_release_handles_unquoted(tmp_path):
+    p = tmp_path / "os-release"
+    p.write_text("PRETTY_NAME=Debian\n")
+    assert sysinfo.read_os_release(str(p)) == "Debian"
+
+
+def test_read_os_release_missing_falls_back(tmp_path):
+    result = sysinfo.read_os_release(str(tmp_path / "nope"))
+    assert result and isinstance(result, str)
+
+
+def test_read_temperature_parses_millicelsius(tmp_path):
+    p = tmp_path / "temp"
+    p.write_text("48123\n")
+    assert sysinfo.read_temperature(str(p)) == "48.1°C"
+
+
+def test_read_temperature_missing_is_na(tmp_path):
+    assert sysinfo.read_temperature(str(tmp_path / "nope")) == "n/a"
+
+
+def test_read_temperature_garbage_is_na(tmp_path):
+    p = tmp_path / "temp"
+    p.write_text("not-a-number")
+    assert sysinfo.read_temperature(str(p)) == "n/a"
+
+
+def test_read_loadavg_uses_injected():
+    assert sysinfo.read_loadavg(getloadavg=lambda: (0.5, 1.0, 2.0)) == (0.5, 1.0, 2.0)
+
+
+def test_read_loadavg_oserror_defaults_to_zeros():
+    def boom():
+        raise OSError("no procfs")
+
+    assert sysinfo.read_loadavg(getloadavg=boom) == (0.0, 0.0, 0.0)
+
+
+def test_read_disk_free_returns_free_total():
+    fake = _DiskUsage(total=1000, used=400, free=600)
+    free, total = sysinfo.read_disk_free("/", disk_usage=lambda _: fake)
+    assert (free, total) == (600, 1000)
+
+
+def test_format_bytes_units():
+    assert sysinfo.format_bytes(0) == "0.0 B"
+    assert sysinfo.format_bytes(1023) == "1023.0 B"
+    assert sysinfo.format_bytes(1024) == "1.0 KB"
+    assert sysinfo.format_bytes(2 * 1024 * 1024) == "2.0 MB"
+    assert sysinfo.format_bytes(5 * 1024 ** 3) == "5.0 GB"

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -16,6 +16,16 @@ def _all_words(conn: sqlite3.Connection) -> list[str]:
     return [r["text"] for r in conn.execute("SELECT text FROM words").fetchall()]
 
 
+def test_count_words_is_per_chat(conn: sqlite3.Connection) -> None:
+    assert vocab.count_words(conn, CHAT) == 0
+    vocab.add_word(conn, CHAT, "alpha")
+    vocab.add_word(conn, CHAT, "beta")
+    vocab.add_word(conn, CHAT + 1, "gamma")  # different chat
+    assert vocab.count_words(conn, CHAT) == 2
+    assert vocab.count_words(conn, CHAT + 1) == 1
+    assert vocab.count_words(conn, 999) == 0
+
+
 def test_add_word_returns_true_for_new(conn: sqlite3.Connection) -> None:
     assert vocab.add_word(conn, CHAT, "ephemeral") is True
     assert _all_words(conn) == ["ephemeral"]

--- a/vocab.py
+++ b/vocab.py
@@ -123,6 +123,15 @@ def list_words(
     ).fetchall()
 
 
+def count_words(conn: sqlite3.Connection, chat_id: int) -> int:
+    """Return how many vocab rows exist for `chat_id`."""
+    row = conn.execute(
+        "SELECT COUNT(*) FROM words WHERE chat_id = ?",
+        (chat_id,),
+    ).fetchone()
+    return row[0] if row else 0
+
+
 def scan_mentions(text: str, words: list[tuple[int, str]]) -> list[int]:
     """Return ids of vocab words that appear as literal substrings in `text`.
 


### PR DESCRIPTION
## Summary
- Renames \`/model\` → \`/status\`.
- Adds hardware, OS, load average, CPU temp, disk-free on \`/\`, and per-chat vocab count alongside the existing llama.cpp endpoint/health.
- Adds a short model bench (tiny prompt, 30 s timeout). On success prints \`N chars in Xs (~Y tok/s)\`; on timeout prints \`model not responding\`; on other errors prints \`error: <ExceptionType>\`.

## Structure
- New \`sysinfo.py\` — pure readers with injectable dependencies (\`getloadavg\`, \`disk_usage\`, file paths) so tests can supply fakes, and safe fallbacks so it works off-Pi.
- \`llm.bench(chat_fn=..., timeout=30, now=...)\` — orchestrates the timed call; \`chat_fn\` defaults to \`llm.chat\` in production and is injected in tests.
- \`vocab.count_words(conn, chat_id)\` — simple COUNT query.
- \`bot.cmd_status\` wires them together; COMMANDS list and help reflect the new name.

## Impact on live bot
- User-visible command rename: \`/model\` → \`/status\`. Anyone with muscle memory / pinned shortcuts will need to re-tap.
- The bench call adds up to 30 s to the /status response when the model is overloaded or down. Nothing else changes.

## Test plan
- [x] \`python -m py_compile bot.py sysinfo.py llm.py vocab.py\`
- [x] \`python -m pytest -q\` — 108 passed (+16 new: sysinfo readers, bench success/timeout/error, count_words)
- [x] Ran sysinfo helpers locally on the Pi — hardware/OS/load/temp/disk all return real values.
- [ ] Smoke-test on the Pi: send \`/status\`, verify all fields populate and bench returns a reasonable tok/s.