### PR TITLE
feat: show 0-100 priority score per word in /list

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -377,7 +377,11 @@ async def cmd_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         + (f" matching '{needle}'" if needle else "")
         + ":"
     )
-    lines = [f"• {r['text']} (seen {r['mention_count']}×)" for r in rows]
+    scores = vocab.compute_scores(rows)
+    lines = [
+        f"• {r['text']} (seen {r['mention_count']}×, score {s})"
+        for r, s in zip(rows, scores)
+    ]
     # Telegram message cap — truncate gracefully.
     body = "\n".join(lines)
     if len(body) > MAX_MSG_LEN - len(header) - 32:

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -123,6 +123,36 @@ def test_weight_drops_for_just_learned_word(conn: sqlite3.Connection) -> None:
     assert w < 4.5
 
 
+# --- compute_scores ----------------------------------------------------------
+
+
+def test_compute_scores_empty_returns_empty() -> None:
+    assert vocab.compute_scores([]) == []
+
+
+def test_compute_scores_single_row_is_full(conn: sqlite3.Connection) -> None:
+    vocab.add_word(conn, CHAT, "solo")
+    rows = conn.execute("SELECT * FROM words WHERE chat_id=?", (CHAT,)).fetchall()
+    assert vocab.compute_scores(rows) == [100]
+
+
+def test_compute_scores_normalizes_against_max(conn: sqlite3.Connection) -> None:
+    # fresh unrated → weight ≈ 8 (top)
+    # mastered (just Good-rated) → weight < 4.5
+    vocab.add_word(conn, CHAT, "fresh")
+    vocab.add_word(conn, CHAT, "mastered")
+    vocab.rate_word(conn, _wid(conn, "mastered"), Rating.Good)
+
+    rows = conn.execute(
+        "SELECT * FROM words WHERE chat_id=? ORDER BY text", (CHAT,)
+    ).fetchall()
+    scores = vocab.compute_scores(rows, datetime.datetime.now(UTC))
+    by_text = dict(zip([r["text"] for r in rows], scores))
+    assert by_text["fresh"] == 100
+    assert 0 < by_text["mastered"] < 100
+    assert by_text["mastered"] < by_text["fresh"]
+
+
 # --- select_word -------------------------------------------------------------
 
 

--- a/vocab.py
+++ b/vocab.py
@@ -227,6 +227,24 @@ def compute_weight(row: sqlite3.Row, now: datetime.datetime) -> float:
     return (1 + forget_prob) * (1 + recency_boost) * (1 + rarity_boost)
 
 
+def compute_scores(
+    rows: list[sqlite3.Row],
+    now: datetime.datetime | None = None,
+) -> list[int]:
+    """Normalize per-row weights to 0..100 integers against the list's max.
+
+    Empty input returns []. If all weights tie, every row scores 100.
+    """
+    if not rows:
+        return []
+    now = now or _now_dt()
+    weights = [compute_weight(r, now) for r in rows]
+    top = max(weights)
+    if top <= 0:
+        return [0] * len(rows)
+    return [round(w / top * 100) for w in weights]
+
+
 def select_word(
     conn: sqlite3.Connection,
     chat_id: int,


### PR DESCRIPTION
## Summary
- New pure helper \`vocab.compute_scores(rows, now)\` that normalizes per-row selection weights to integers in 0..100 against the list's max.
- \`/list\` now renders each line as \`• word (seen N×, score S)\` so the user can see which words the agent treats as most urgent (same signal that drives push selection: FSRS forget-prob × recency × rarity).
- Tests cover empty input, single-row (always 100), and relative ordering between a fresh unrated word and a just-reviewed one.

## Test plan
- [x] \`python -m py_compile bot.py vocab.py\`
- [x] \`pytest -q\` → 122 passed
- [ ] \`/list\` in the live bot shows \`score\` column next to \`seen\` count