### PR TITLE
feat: bold vocab matches in bot replies

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -155,25 +155,25 @@ def is_allowed(update: Update) -> bool:
 # --- telegram send helpers --------------------------------------------------
 
 
-async def safe_edit(message, text: str) -> None:
+async def safe_edit(message, text: str, *, parse_mode: str | None = None) -> None:
     """Edit a Telegram message, handling rate-limit and no-change errors."""
     try:
-        await message.edit_text(text)
+        await message.edit_text(text, parse_mode=parse_mode)
     except RetryAfter as e:
         await asyncio.sleep(e.retry_after + 0.5)
-        await message.edit_text(text)
+        await message.edit_text(text, parse_mode=parse_mode)
     except BadRequest as e:
         if "message is not modified" not in str(e).lower():
             raise
 
 
-async def safe_send(bot, chat_id: int, text: str):
+async def safe_send(bot, chat_id: int, text: str, *, parse_mode: str | None = None):
     """Send a new Telegram message, retrying once on RetryAfter."""
     try:
-        return await bot.send_message(chat_id=chat_id, text=text)
+        return await bot.send_message(chat_id=chat_id, text=text, parse_mode=parse_mode)
     except RetryAfter as e:
         await asyncio.sleep(e.retry_after + 0.5)
-        return await bot.send_message(chat_id=chat_id, text=text)
+        return await bot.send_message(chat_id=chat_id, text=text, parse_mode=parse_mode)
 
 
 def split_point(text: str, max_len: int) -> int:
@@ -219,8 +219,12 @@ async def dispatch_push(chat_id: int) -> None:
             ),
         ]]
     )
+    chat_words = [r["text"] for r in vocab.list_words(conn, chat_id)]
+    formatted = vocab.bold_matches(text, chat_words)
     try:
-        msg = await app.bot.send_message(chat_id=chat_id, text=text, reply_markup=kb)
+        msg = await app.bot.send_message(
+            chat_id=chat_id, text=formatted, reply_markup=kb, parse_mode="HTML"
+        )
         conn.execute(
             "UPDATE push_log SET tg_message_id = ? WHERE id = ?",
             (msg.message_id, push_id),
@@ -514,13 +518,16 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not explanation:
         return
     chat_id = update.effective_chat.id
+    # Reuse the rated word's text for the transcript tag and to bold it inline.
+    row = conn.execute(
+        "SELECT text FROM words WHERE id = ?", (word_id,)
+    ).fetchone()
+    tag_word = row["text"] if row is not None else "?"
+    formatted = vocab.bold_matches(
+        explanation, [tag_word] if row is not None else []
+    )
     try:
-        await query.message.reply_text(explanation)
-        # Best-effort: reuse the rated word's text for the transcript tag.
-        row = conn.execute(
-            "SELECT text FROM words WHERE id = ?", (word_id,)
-        ).fetchone()
-        tag_word = row["text"] if row is not None else "?"
+        await query.message.reply_text(formatted, parse_mode="HTML")
         append_turn(chat_id, "explain", f"[{tag_word}] {explanation}")
     except Exception as e:  # noqa: BLE001
         log.error("failed to send explanation for chat %s: %s", chat_id, e)
@@ -597,6 +604,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     accumulated = ""
     last_edit = asyncio.get_event_loop().time()
 
+    def fmt(s: str) -> str:
+        return vocab.bold_matches(s, word_texts)
+
     try:
         async for token in llm.stream_chat(histories[chat_id]):
             accumulated += token
@@ -605,25 +615,25 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             while len(current_page) > MAX_MSG_LEN:
                 idx = split_point(current_page, MAX_MSG_LEN)
                 head, current_page = current_page[:idx], current_page[idx:]
-                await safe_edit(current_msg, head)
+                await safe_edit(current_msg, fmt(head), parse_mode="HTML")
                 current_msg = await safe_send(
-                    context.bot, chat_id, current_page + CURSOR
+                    context.bot, chat_id, fmt(current_page + CURSOR), parse_mode="HTML"
                 )
                 last_edit = asyncio.get_event_loop().time()
 
             now = asyncio.get_event_loop().time()
             if now - last_edit >= EDIT_INTERVAL:
-                await safe_edit(current_msg, current_page + CURSOR)
+                await safe_edit(current_msg, fmt(current_page + CURSOR), parse_mode="HTML")
                 last_edit = now
 
     except Exception as e:
         log.error("Streaming error: %s", e)
         append_turn(chat_id, "error", f"{type(e).__name__}: {e}")
-        await safe_edit(current_msg, current_page or f"⚠️ Error: {e}")
+        await safe_edit(current_msg, fmt(current_page or f"⚠️ Error: {e}"), parse_mode="HTML")
         return
 
     final_text = current_page or "⚠️ No response from model."
-    await safe_edit(current_msg, final_text)
+    await safe_edit(current_msg, fmt(final_text), parse_mode="HTML")
 
     histories[chat_id].append({"role": "assistant", "content": accumulated})
     append_turn(chat_id, "assistant", accumulated)

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -121,6 +121,43 @@ def test_scan_mentions_empty_inputs() -> None:
     assert vocab.scan_mentions("", [(1, "hello")]) == []
 
 
+def test_bold_matches_empty_text() -> None:
+    assert vocab.bold_matches("", ["foo"]) == ""
+
+
+def test_bold_matches_no_words_just_escapes() -> None:
+    assert vocab.bold_matches("a < b & c", []) == "a &lt; b &amp; c"
+
+
+def test_bold_matches_wraps_substring_case_insensitive() -> None:
+    out = vocab.bold_matches("It was Serendipity, brief.", ["serendipity"])
+    assert out == "It was <b>Serendipity</b>, brief."
+
+
+def test_bold_matches_escapes_html_chars_outside_match() -> None:
+    out = vocab.bold_matches("<cat> & dog", ["cat"])
+    assert out == "&lt;<b>cat</b>&gt; &amp; dog"
+
+
+def test_bold_matches_longer_word_wins_on_overlap() -> None:
+    out = vocab.bold_matches("concatenate things", ["cat", "concatenate"])
+    assert out == "<b>concatenate</b> things"
+
+
+def test_bold_matches_multiple_non_overlapping() -> None:
+    out = vocab.bold_matches("cat dog cat", ["cat", "dog"])
+    assert out == "<b>cat</b> <b>dog</b> <b>cat</b>"
+
+
+def test_bold_matches_phrase() -> None:
+    out = vocab.bold_matches("She did it on the fly today.", ["on the fly"])
+    assert out == "She did it <b>on the fly</b> today."
+
+
+def test_bold_matches_ignores_empty_word_entries() -> None:
+    assert vocab.bold_matches("hello world", ["", "world"]) == "hello <b>world</b>"
+
+
 def test_bump_mentions_increments_and_timestamps(conn: sqlite3.Connection) -> None:
     vocab.add_word(conn, CHAT, "placid")
     wid = conn.execute("SELECT id FROM words").fetchone()["id"]

--- a/vocab.py
+++ b/vocab.py
@@ -16,6 +16,7 @@ so no single signal dominates and randomness is baked into `random.choices`.
 from __future__ import annotations
 
 import datetime
+import html
 import math
 import random
 import sqlite3
@@ -140,6 +141,42 @@ def scan_mentions(text: str, words: list[tuple[int, str]]) -> list[int]:
     """
     haystack = text.lower()
     return [wid for wid, w in words if w and w in haystack]
+
+
+def bold_matches(text: str, words: list[str]) -> str:
+    """HTML-escape `text` and wrap any vocab-word substrings in <b>…</b>.
+
+    Mirrors `scan_mentions`'s case-insensitive substring match. When two
+    candidate words would overlap (e.g. "cat" inside "concatenate") the
+    longer one wins, so we never bold a fragment of a longer match. Returns
+    a string safe to send with Telegram's HTML parse mode.
+    """
+    if not text:
+        return ""
+    haystack = text.lower()
+    spans: list[tuple[int, int]] = []
+    for w in sorted({w for w in words if w}, key=len, reverse=True):
+        i = 0
+        while True:
+            idx = haystack.find(w, i)
+            if idx == -1:
+                break
+            end = idx + len(w)
+            i = end
+            if any(s < end and idx < e for s, e in spans):
+                continue
+            spans.append((idx, end))
+    spans.sort()
+    out: list[str] = []
+    cursor = 0
+    for s, e in spans:
+        out.append(html.escape(text[cursor:s]))
+        out.append("<b>")
+        out.append(html.escape(text[s:e]))
+        out.append("</b>")
+        cursor = e
+    out.append(html.escape(text[cursor:]))
+    return "".join(out)
 
 
 def bump_mentions(conn: sqlite3.Connection, word_ids: list[int]) -> None:


### PR DESCRIPTION
## Summary
- New pure helper `vocab.bold_matches(text, words)` HTML-escapes text and wraps any vocab-substring matches in `<b>…</b>` (longer-word-wins on overlap, mirrors `scan_mentions`'s case-insensitive substring rule).
- `bot.py` now sends streaming chat replies, scheduled pushes, and forgot-explanations with `parse_mode="HTML"`, routing every outbound text through `bold_matches` so vocab terms stand out.
- `safe_edit` / `safe_send` gained an optional `parse_mode` kwarg.

Bot impact: streaming edits and pushes now go out with `parse_mode="HTML"`. Arbitrary model output is HTML-escaped before send, so unbalanced `<` / `&` from the LLM won't cause `BadRequest`. Worst-case length: each match adds 7 chars (`<b></b>`) on top of `MAX_MSG_LEN = 4000` — within Telegram's 4096 limit for typical message density.

## Test plan
- [x] `python -m py_compile bot.py vocab.py`
- [x] `python -m pytest -q` — 130 passed (8 new tests for `bold_matches`)
- [ ] Manual smoke on the live bot: send a chat that uses a vocab word; trigger a push; tap ❌ forgot to confirm the explanation message renders bold correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)