### PR TITLE
fix: strip markdown bold markers before HTML render

### DIFF
--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -158,6 +158,28 @@ def test_bold_matches_ignores_empty_word_entries() -> None:
     assert vocab.bold_matches("hello world", ["", "world"]) == "hello <b>world</b>"
 
 
+def test_bold_matches_strips_markdown_bold_around_vocab_word() -> None:
+    out = vocab.bold_matches(
+        "It's a testament to **strength** today.", ["strength"]
+    )
+    assert out == "It&#x27;s a testament to <b>strength</b> today."
+
+
+def test_bold_matches_strips_markdown_bold_when_word_not_in_vocab() -> None:
+    out = vocab.bold_matches("truly **remarkable** indeed", [])
+    assert out == "truly remarkable indeed"
+
+
+def test_bold_matches_strips_underscore_markdown_bold() -> None:
+    out = vocab.bold_matches("__placid__ waters", ["placid"])
+    assert out == "<b>placid</b> waters"
+
+
+def test_bold_matches_handles_multiple_markdown_chunks() -> None:
+    out = vocab.bold_matches("**alpha** then **beta** end", ["beta"])
+    assert out == "alpha then <b>beta</b> end"
+
+
 def test_bump_mentions_increments_and_timestamps(conn: sqlite3.Connection) -> None:
     vocab.add_word(conn, CHAT, "placid")
     wid = conn.execute("SELECT id FROM words").fetchone()["id"]

--- a/vocab.py
+++ b/vocab.py
@@ -19,6 +19,7 @@ import datetime
 import html
 import math
 import random
+import re
 import sqlite3
 
 from fsrs import Card, Rating, Scheduler, State
@@ -143,16 +144,22 @@ def scan_mentions(text: str, words: list[tuple[int, str]]) -> list[int]:
     return [wid for wid, w in words if w and w in haystack]
 
 
+_MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*|__(.+?)__", re.DOTALL)
+
+
 def bold_matches(text: str, words: list[str]) -> str:
     """HTML-escape `text` and wrap any vocab-word substrings in <b>…</b>.
 
     Mirrors `scan_mentions`'s case-insensitive substring match. When two
     candidate words would overlap (e.g. "cat" inside "concatenate") the
-    longer one wins, so we never bold a fragment of a longer match. Returns
-    a string safe to send with Telegram's HTML parse mode.
+    longer one wins, so we never bold a fragment of a longer match. Markdown
+    bold markers (`**x**` / `__x__`) the model sometimes emits are stripped
+    first — Telegram's HTML mode would otherwise render them literally.
+    Returns a string safe to send with Telegram's HTML parse mode.
     """
     if not text:
         return ""
+    text = _MD_BOLD_RE.sub(lambda m: m.group(1) or m.group(2), text)
     haystack = text.lower()
     spans: list[tuple[int, int]] = []
     for w in sorted({w for w in words if w}, key=len, reverse=True):


### PR DESCRIPTION
## Summary
- `vocab.bold_matches` now strips `**…**` and `__…__` Markdown bold pairs from input before applying its own `<b>…</b>` wrapping.
- Why: Gemma sometimes emits its own emphasis (e.g. `**strength**`); under Telegram HTML mode those markers rendered literally as `**` next to a vocab-bolded word, looking broken.
- Net effect: vocab words still render bold; model-emitted Markdown bold just degrades to clean plain text.

Bot impact: only affects `bold_matches` output — every place that already routed through it (chat replies, pushes, forgot-explanations) gets cleaner text.

## Test plan
- [x] `python -m py_compile bot.py vocab.py`
- [x] `python -m pytest -q` — 134 passed (4 new tests covering markdown-strip cases)
- [ ] Manual smoke: trigger a chat reply that the model decorates with `**…**` and confirm Telegram shows clean bold without literal asterisks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)