### PR TITLE
Reply on forgot-rated push with explanation + translation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -529,9 +529,29 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     formatted = vocab.bold_matches(
         explanation, [tag_word] if row is not None else []
     )
+
+    # Tack on a single-word translation into the chat's configured target
+    # language. A failure here mustn't drop the explanation itself.
+    translation: str | None = None
+    settings = config_flow.load_settings(conn, chat_id)
+    if settings is not None:
+        try:
+            translation = await sched_module.compose_translation(
+                conn,
+                word_id,
+                settings.target_lang,
+                translate_fn=lambda w, t: asyncio.to_thread(
+                    translator.translate, w, t, "en"
+                ),
+            )
+        except Exception as e:  # noqa: BLE001
+            log.error("translate for explain failed for word %s: %s", word_id, e)
+
+    body = sched_module.format_explanation_reply(formatted, translation)
+    transcript = explanation if not translation else f"{explanation}\n→ {translation}"
     try:
-        await query.message.reply_text(formatted, parse_mode="HTML")
-        append_turn(chat_id, "explain", f"[{tag_word}] {explanation}")
+        await query.message.reply_text(body, parse_mode="HTML", do_quote=True)
+        append_turn(chat_id, "explain", f"[{tag_word}] {transcript}")
     except Exception as e:  # noqa: BLE001
         log.error("failed to send explanation for chat %s: %s", chat_id, e)
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -17,6 +17,7 @@ caller's job so bot.py can include the Telegram message id.
 from __future__ import annotations
 
 import datetime
+import html
 import json
 import logging
 import random
@@ -93,6 +94,7 @@ def plan_push_times(
 
 # Injected type aliases for clarity.
 LlmChat = Callable[[list[dict]], Awaitable[str]]
+TranslateFn = Callable[[str, str], Awaitable[str]]
 
 
 async def compose_push(
@@ -149,6 +151,51 @@ async def compose_explanation(
         return None
     text = (await llm_chat(prompts.explain_messages(row["text"]))).strip()
     return text or None
+
+
+async def compose_translation(
+    conn: sqlite3.Connection,
+    word_id: int,
+    target: str,
+    *,
+    translate_fn: TranslateFn,
+) -> str | None:
+    """Translate the rated word into `target` (ISO code) for the ❌-forgot reply.
+
+    Mirrors `compose_explanation`'s contract: returns the stripped translation,
+    or None when the word is gone or the result is empty. Callers wrap the
+    sync `translator.translate` in `asyncio.to_thread` to satisfy `translate_fn`.
+    """
+    row = conn.execute(
+        "SELECT text FROM words WHERE id = ?", (word_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    text = (await translate_fn(row["text"], target)).strip()
+    return text or None
+
+
+# Visual divider between the LLM explanation and the single-word translation.
+# A box-drawing rule keeps the two sections distinct without leaning on emoji.
+_EXPLAIN_DIVIDER = "──────────"
+
+
+def format_explanation_reply(
+    explanation_html: str, translation: str | None
+) -> str:
+    """Compose the ❌-forgot reply body — explanation, then optional translation.
+
+    `explanation_html` is already HTML-safe (typically from `vocab.bold_matches`).
+    `translation` is plain text and gets HTML-escaped here. When translation is
+    None or empty the reply is just the explanation, unchanged.
+    """
+    if not translation:
+        return explanation_html
+    return (
+        f"{explanation_html}\n\n"
+        f"{_EXPLAIN_DIVIDER}\n"
+        f"<i>{html.escape(translation)}</i>"
+    )
 
 
 def log_push(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -297,6 +297,96 @@ def test_compose_explanation_returns_none_on_empty_llm_reply(conn: sqlite3.Conne
     assert out is None
 
 
+# --- compose_translation -----------------------------------------------------
+
+
+def test_compose_translation_returns_stripped_text(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "ephemeral")
+    row = conn.execute(
+        "SELECT id FROM words WHERE chat_id = ?", (CHAT,)
+    ).fetchone()
+
+    seen: list[tuple[str, str]] = []
+
+    async def fake_translate(word: str, target: str) -> str:
+        seen.append((word, target))
+        return "  эфемерный  \n"
+
+    out = asyncio.run(
+        scheduler.compose_translation(
+            conn, row["id"], "ru", translate_fn=fake_translate
+        )
+    )
+    assert out == "эфемерный"
+    assert seen == [("ephemeral", "ru")]
+
+
+def test_compose_translation_returns_none_for_unknown_word(conn: sqlite3.Connection) -> None:
+    async def fake_translate(word: str, target: str) -> str:
+        raise AssertionError("translator should not be called")
+
+    out = asyncio.run(
+        scheduler.compose_translation(
+            conn, 99999, "ru", translate_fn=fake_translate
+        )
+    )
+    assert out is None
+
+
+def test_compose_translation_returns_none_on_empty_result(conn: sqlite3.Connection) -> None:
+    _seed_chat(conn)
+    vocab.add_word(conn, CHAT, "placid")
+    row = conn.execute(
+        "SELECT id FROM words WHERE chat_id = ?", (CHAT,)
+    ).fetchone()
+
+    async def fake_blank(word: str, target: str) -> str:
+        return "  \n"
+
+    out = asyncio.run(
+        scheduler.compose_translation(
+            conn, row["id"], "ru", translate_fn=fake_blank
+        )
+    )
+    assert out is None
+
+
+# --- format_explanation_reply ------------------------------------------------
+
+
+def test_format_explanation_reply_without_translation_is_passthrough() -> None:
+    assert (
+        scheduler.format_explanation_reply("Means lasting briefly.", None)
+        == "Means lasting briefly."
+    )
+    # Empty string is treated like None — no divider noise on a missing translation.
+    assert (
+        scheduler.format_explanation_reply("Means lasting briefly.", "")
+        == "Means lasting briefly."
+    )
+
+
+def test_format_explanation_reply_appends_divider_and_translation() -> None:
+    out = scheduler.format_explanation_reply(
+        "Means <b>lasting</b> briefly.", "эфемерный"
+    )
+    # Two blank lines + a horizontal rule visually separate the two blocks.
+    assert out == (
+        "Means <b>lasting</b> briefly.\n\n"
+        "──────────\n"
+        "<i>эфемерный</i>"
+    )
+
+
+def test_format_explanation_reply_escapes_translation_html() -> None:
+    out = scheduler.format_explanation_reply("ok", "<script>x</script>")
+    # The translation must be HTML-escaped — Telegram parses the reply as HTML
+    # and a stray '<' would either fail to render or be interpreted as a tag.
+    assert "&lt;script&gt;x&lt;/script&gt;" in out
+    assert "<script>" not in out
+
+
 # --- log_push / mark_rated ---------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Tapping ❌ **forgot** on a push now posts the explanation as a Telegram **reply** (quoting the rated push), so it's obvious which push the follow-up belongs to when several are open.
- The reply also includes a one-shot translation of the rated word into the chat's configured `translate_target` language, visually separated from the LLM explanation by a horizontal-rule line.
- Translation is HTML-escaped before being placed inside Telegram's HTML parse mode; a translate failure is logged and the explanation goes out alone (rating is already applied earlier).

## Implementation notes
- New pure helpers in `scheduler.py`:
  - `compose_translation(conn, word_id, target, *, translate_fn)` — symmetric with `compose_explanation`; keeps the network call out of `bot.py`.
  - `format_explanation_reply(explanation_html, translation)` — composes the final HTML body, divider included, escapes the translation.
- `bot.py` `on_rate` loads chat settings, wraps `translator.translate` in `asyncio.to_thread` (forced `source='en'` since vocab is English), and sends with `do_quote=True`.
- ✅ knew path is unchanged.

## Test plan
- [x] `python -m py_compile bot.py scheduler.py`
- [x] `python -m pytest -q` — 147 passed (4 new tests for `compose_translation`, 3 new for `format_explanation_reply`).
- [ ] On a live chat, tap ❌ forgot on a push and confirm the reply quotes the rated message and shows `<explanation>` + divider + italic translation in the chat's target language.
- [ ] On a chat with no settings (edge case) the explanation still posts without translation.