### PR TITLE
feat: OpenRouter backend dispatch in llm.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@ SYSTEM_PROMPT=You are a friendly English tutor chatting casually with a learner.
 # Comma-separated Telegram user IDs allowed to chat with the bot.
 # Leave empty/unset to allow everyone.
 ALLOWED_USER_IDS=
+
+# LLM backend: 'llama' (default; local llama.cpp on http://127.0.0.1:8080)
+# or 'openrouter' (cloud fallback, smoke/test only — model differs from the Pi).
+LLM_BACKEND=llama
+# Required when LLM_BACKEND=openrouter.
+OPENROUTER_API_KEY=
+# Optional override; defaults to google/gemma-4-26b-a4b-it:free.
+OPENROUTER_MODEL=google/gemma-4-26b-a4b-it:free

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ Slot numbers live in `<git-dir>/wt-slot` (per-worktree git metadata, invisible t
 | `TELEGRAM_TOKEN` | Yes | — |
 | `SYSTEM_PROMPT` | No | `"You are a friendly English tutor chatting casually with a learner. Use natural, everyday English. If they ask about grammar, vocabulary, or usage, explain briefly with a small example."` |
 | `ALLOWED_USER_IDS` | No | empty (allow all) — comma/whitespace-separated Telegram user IDs; if set, other users are silently ignored and logged |
+| `LLM_BACKEND` | No | `llama` — local llama.cpp on `http://127.0.0.1:8080`. Set to `openrouter` to route chat completions to OpenRouter instead (used by parallel-agent worktrees that can't reach the Pi). |
+| `OPENROUTER_API_KEY` | When `LLM_BACKEND=openrouter` | — sent as `Authorization: Bearer <key>`. Empty value with `LLM_BACKEND=openrouter` raises at the first LLM call. |
+| `OPENROUTER_MODEL` | No | `google/gemma-4-26b-a4b-it:free`. Free-tier model, used for smoke testing only — responses will diverge from the Pi's Gemma-4. |
 
 Per-chat scheduling settings (timezone, pushes-per-day, active window, tone) are collected via the `/start` conversation flow and stored in SQLite — they are **not** environment variables.
 

--- a/llm.py
+++ b/llm.py
@@ -1,11 +1,17 @@
-"""Thin async client for llama.cpp's OpenAI-compatible HTTP server.
+"""Thin async client for an OpenAI-compatible chat-completions endpoint.
 
-Exposes three entry points:
+Default backend is the local llama.cpp server on port 8080. When
+``LLM_BACKEND=openrouter`` is set in the environment, the same calls are
+routed to OpenRouter instead — used by parallel-agent worktrees that don't
+have access to the Pi's llama.cpp server. Both backends speak the same
+OpenAI SSE/JSON dialect, so the parsing helpers don't branch.
+
+Entry points:
   * `stream_chat(messages)` — async generator yielding token deltas for live
     Telegram message edits.
   * `chat(messages)` — non-streaming one-shot, used by the push scheduler where
     we wait for the full reply before sending.
-  * `health()` — status string for /model.
+  * `health()` — status string for /status.
 
 SSE parsing and non-stream response parsing are factored into pure helpers so
 they can be unit-tested without standing up an HTTP mock.
@@ -15,7 +21,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
+from dataclasses import dataclass
 from typing import AsyncIterator, Awaitable, Callable
 
 import httpx
@@ -26,7 +34,42 @@ LLAMA_URL = f"{LLAMA_BASE}/v1/chat/completions"
 HEALTH_URL = f"{LLAMA_BASE}/health"
 MODEL = "gemma4"
 
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_OPENROUTER_MODEL = "google/gemma-4-26b-a4b-it:free"
+
 _DONE = "[DONE]"
+
+
+@dataclass(frozen=True)
+class Backend:
+    """Where to send chat-completion requests."""
+
+    name: str
+    url: str
+    model: str
+    headers: dict[str, str]
+
+
+def _get_backend() -> Backend:
+    """Pick a backend from env each call so tests and live config can swap freely."""
+    if os.getenv("LLM_BACKEND", "").strip().lower() == "openrouter":
+        api_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError(
+                "LLM_BACKEND=openrouter but OPENROUTER_API_KEY is empty"
+            )
+        return Backend(
+            name="openrouter",
+            url=OPENROUTER_URL,
+            model=os.getenv("OPENROUTER_MODEL", "").strip() or DEFAULT_OPENROUTER_MODEL,
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+    return Backend(
+        name="llama.cpp",
+        url=LLAMA_URL,
+        model=MODEL,
+        headers={},
+    )
 
 
 def _parse_sse_delta(raw: str) -> str | None:
@@ -53,13 +96,15 @@ async def stream_chat(
     max_tokens: int = 1024,
     temperature: float = 0.7,
 ) -> AsyncIterator[str]:
-    """Stream token deltas from llama.cpp as they arrive."""
+    """Stream token deltas from the configured backend as they arrive."""
+    backend = _get_backend()
     async with httpx.AsyncClient(timeout=180) as client:
         async with client.stream(
             "POST",
-            LLAMA_URL,
+            backend.url,
+            headers=backend.headers,
             json={
-                "model": MODEL,
+                "model": backend.model,
                 "messages": messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
@@ -80,11 +125,13 @@ async def chat(
     temperature: float = 0.8,
 ) -> str:
     """Return the full assistant reply as a single string (no streaming)."""
+    backend = _get_backend()
     async with httpx.AsyncClient(timeout=180) as client:
         r = await client.post(
-            LLAMA_URL,
+            backend.url,
+            headers=backend.headers,
             json={
-                "model": MODEL,
+                "model": backend.model,
                 "messages": messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
@@ -96,7 +143,14 @@ async def chat(
 
 
 async def health() -> str:
-    """Return the llama.cpp server's self-reported status, or an error string."""
+    """Return the backend's self-reported status, or an error string.
+
+    OpenRouter has no public health endpoint, so we report the configured
+    model name without making a request — keeps `/status` snappy.
+    """
+    backend = _get_backend()
+    if backend.name == "openrouter":
+        return f"openrouter (model={backend.model})"
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             r = await client.get(HEALTH_URL)

--- a/parallel-agentic-plan.md
+++ b/parallel-agentic-plan.md
@@ -80,15 +80,24 @@ gh issue list \
 **Risk:** Python `.venv` isn't trivially portable across worktrees. Symlink approach verified in #32 — works for this repo because none of the deps in `requirements.txt` bake absolute paths into installed scripts/wheels.
 
 ### Task 2 — Dual-backend LLM + token pool
+
+**Status:** Code merged in [#33](https://github.com/valdisd96/gemma-rpi-agent/pull/33). Implementation notes to carry forward:
+- Backend selection lives in `llm._get_backend()`, which reads `LLM_BACKEND`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL` from env on each call (not at import). Anything that needs to know the current backend should call this helper rather than re-derive it from env.
+- `LLM_BACKEND` matching is case-insensitive on the string `openrouter`. Anything else (including unset, empty, typos) falls back to the llama.cpp path — keeps the live Pi deployment immune to env-var noise.
+- Missing `OPENROUTER_API_KEY` while `LLM_BACKEND=openrouter` raises `RuntimeError` lazily on the first LLM call, not at startup. `bot.py` is intentionally not coupled to backend validation.
+- `health()` short-circuits for OpenRouter and returns `"openrouter (model=<name>)"` without a network round-trip — kept `/status` snappy and avoided burning the auth-key probe quota.
+- Slot env files (`env/slot1.env`, `env/slot2.env`) remain gitignored and per-machine. `wt.sh` from #32 seeds them from `.env.example`, so each new worktree starts with the right schema (TELEGRAM_TOKEN + the three OpenRouter keys) ready to fill in.
+- Tests use `httpx.MockTransport` patched onto `httpx.AsyncClient` via `monkeypatch` — useful pattern when Task 4/5 code needs to assert request shape without standing up a fake server.
+
 **Deliverables**
 - `env/slot1.env`, `env/slot2.env` (gitignored) each with its `TELEGRAM_TOKEN` + `OPENROUTER_API_KEY`.
 - `llm.py`: tiny dispatch — when `LLM_BACKEND=openrouter`, call `https://openrouter.ai/api/v1/chat/completions` with `model=google/gemma-4-26b-a4b-it:free`; otherwise current llama.cpp path.
 - `.env.example`: add `LLM_BACKEND`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, documented in `CLAUDE.md`.
-- Smoke: `python bot.py` with `LLM_BACKEND=openrouter` answers a real Telegram message.
+- Smoke: `python bot.py` with `LLM_BACKEND=openrouter` answers a real Telegram message. (Manual; deferred — needs a real Telegram + OpenRouter pair.)
 
 **Risks**
 - OpenRouter free-tier model differs from Gemma-4 on the Pi; responses will diverge. Use for smoke only, not prompt-tuning.
-- Free-tier rate limits — verify current caps during implementation.
+- Free-tier rate limits — not load-tested in #33; default model is `google/gemma-4-26b-a4b-it:free`, swap via `OPENROUTER_MODEL` if quotas bite.
 
 ### Task 3 — Label taxonomy + planner/clarify skills
 **Deliverables**

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,10 +1,48 @@
-"""Tests for llm.py parse helpers and bench (no network)."""
+"""Tests for llm.py parse helpers, backend dispatch, and bench (no network)."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+
+import httpx
+import pytest
 
 import llm
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """Wipe the LLM env vars so each test starts from defaults."""
+    for key in ("LLM_BACKEND", "OPENROUTER_API_KEY", "OPENROUTER_MODEL"):
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_request(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch httpx.AsyncClient to record one POST and reply with a canned body."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content) if request.content else {}
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "ok"}}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    return captured
 
 
 def test_sse_delta_extracts_content() -> None:
@@ -68,3 +106,171 @@ def test_bench_error_reports_exception_type() -> None:
 
     out = asyncio.run(llm.bench(chat_fn=boom))
     assert out == "error: ConnectionError"
+
+
+# _get_backend ----------------------------------------------------------
+
+
+def test_backend_defaults_to_llama(clean_env: pytest.MonkeyPatch) -> None:
+    backend = llm._get_backend()
+    assert backend.name == "llama.cpp"
+    assert backend.url == llm.LLAMA_URL
+    assert backend.model == llm.MODEL
+    assert backend.headers == {}
+
+
+def test_backend_unknown_value_falls_back_to_llama(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("LLM_BACKEND", "claude")
+    assert llm._get_backend().name == "llama.cpp"
+
+
+def test_backend_openrouter_with_key(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("LLM_BACKEND", "openrouter")
+    clean_env.setenv("OPENROUTER_API_KEY", "sk-test")
+    backend = llm._get_backend()
+    assert backend.name == "openrouter"
+    assert backend.url == llm.OPENROUTER_URL
+    assert backend.model == llm.DEFAULT_OPENROUTER_MODEL
+    assert backend.headers == {"Authorization": "Bearer sk-test"}
+
+
+def test_backend_openrouter_uses_custom_model(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("LLM_BACKEND", "openrouter")
+    clean_env.setenv("OPENROUTER_API_KEY", "sk-test")
+    clean_env.setenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku")
+    assert llm._get_backend().model == "anthropic/claude-3-haiku"
+
+
+def test_backend_openrouter_is_case_insensitive(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("LLM_BACKEND", "OpenRouter")
+    clean_env.setenv("OPENROUTER_API_KEY", "k")
+    assert llm._get_backend().name == "openrouter"
+
+
+def test_backend_openrouter_without_key_raises(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("LLM_BACKEND", "openrouter")
+    with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
+        llm._get_backend()
+
+
+# chat() request shape --------------------------------------------------
+
+
+def test_chat_default_posts_to_llama_without_auth(
+    clean_env: pytest.MonkeyPatch,
+    captured_request: dict,
+) -> None:
+    asyncio.run(llm.chat([{"role": "user", "content": "hi"}]))
+    assert captured_request["method"] == "POST"
+    assert captured_request["url"] == llm.LLAMA_URL
+    assert "authorization" not in captured_request["headers"]
+    assert captured_request["body"]["model"] == llm.MODEL
+    assert captured_request["body"]["stream"] is False
+
+
+def test_chat_openrouter_posts_with_bearer_and_model(
+    clean_env: pytest.MonkeyPatch,
+    captured_request: dict,
+) -> None:
+    clean_env.setenv("LLM_BACKEND", "openrouter")
+    clean_env.setenv("OPENROUTER_API_KEY", "sk-secret")
+    asyncio.run(llm.chat([{"role": "user", "content": "hi"}]))
+    assert captured_request["url"] == llm.OPENROUTER_URL
+    assert captured_request["headers"]["authorization"] == "Bearer sk-secret"
+    assert captured_request["body"]["model"] == llm.DEFAULT_OPENROUTER_MODEL
+
+
+# stream_chat() request shape -------------------------------------------
+
+
+def _patch_stream(monkeypatch: pytest.MonkeyPatch, sse_body: bytes) -> dict:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content) if request.content else {}
+        return httpx.Response(
+            200,
+            content=sse_body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    return captured
+
+
+def _collect_stream(messages: list[dict]) -> list[str]:
+    async def run() -> list[str]:
+        return [d async for d in llm.stream_chat(messages)]
+
+    return asyncio.run(run())
+
+
+def test_stream_chat_default_targets_llama(
+    clean_env: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sse = (
+        b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    captured = _patch_stream(monkeypatch, sse)
+    deltas = _collect_stream([{"role": "user", "content": "hi"}])
+    assert deltas == ["hi"]
+    assert captured["url"] == llm.LLAMA_URL
+    assert "authorization" not in captured["headers"]
+    assert captured["body"]["stream"] is True
+
+
+def test_stream_chat_openrouter_carries_bearer(
+    clean_env: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clean_env.setenv("LLM_BACKEND", "openrouter")
+    clean_env.setenv("OPENROUTER_API_KEY", "k")
+    sse = b'data: {"choices":[{"delta":{"content":"x"}}]}\n\ndata: [DONE]\n\n'
+    captured = _patch_stream(monkeypatch, sse)
+    deltas = _collect_stream([{"role": "user", "content": "hi"}])
+    assert deltas == ["x"]
+    assert captured["url"] == llm.OPENROUTER_URL
+    assert captured["headers"]["authorization"] == "Bearer k"
+
+
+# health() --------------------------------------------------------------
+
+
+def test_health_openrouter_returns_synthetic_string(
+    clean_env: pytest.MonkeyPatch,
+) -> None:
+    clean_env.setenv("LLM_BACKEND", "openrouter")
+    clean_env.setenv("OPENROUTER_API_KEY", "k")
+    out = asyncio.run(llm.health())
+    assert out.startswith("openrouter (model=")
+    assert llm.DEFAULT_OPENROUTER_MODEL in out
+
+
+def test_health_llama_unreachable_returns_error_string(
+    clean_env: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated")
+
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    out = asyncio.run(llm.health())
+    assert "unreachable" in out


### PR DESCRIPTION
## Summary

Implements **Task 2** of `parallel-agentic-plan.md` — parallel-agent worktrees on a laptop need an LLM that doesn't depend on the Pi's llama.cpp server.

- `LLM_BACKEND=openrouter` (env) → routes `chat()` and `stream_chat()` to `https://openrouter.ai/api/v1/chat/completions` with `Authorization: Bearer $OPENROUTER_API_KEY`.
- Anything else (default, unset, or any other value) keeps the existing llama.cpp path — no change for the live Pi deployment.
- `_get_backend()` reads env at call time, returning a frozen `Backend(name, url, model, headers)` dataclass. Tests can `monkeypatch.setenv` to swap backends per case.
- `health()` short-circuits for OpenRouter (no public health endpoint) and returns `"openrouter (model=...)"` so `/status` stays snappy.
- `OPENROUTER_MODEL` defaults to `google/gemma-4-26b-a4b-it:free` per the plan; override via env if the free-tier catalog shifts.
- Empty `OPENROUTER_API_KEY` while `LLM_BACKEND=openrouter` raises `RuntimeError` lazily on the first LLM call (visible crash with a clear message — preferred over silent fall-through).

### Test additions

- `_get_backend` permutations: defaults, openrouter with key, custom model, case-insensitive `LLM_BACKEND` value, missing-key error, unknown value falls back to llama.
- `httpx.MockTransport`-backed shape tests for both `chat()` and `stream_chat()`: assert URL, `Authorization` header presence/absence, `model` in body, `stream` flag.
- `health()` openrouter synthetic string + llama unreachable error string.

### Risks (from the plan)

- OpenRouter's free-tier model differs from the Pi's Gemma-4 — outputs will diverge. Smoke only, not for prompt tuning. Documented in `CLAUDE.md`.
- Free-tier rate limits not load-tested here. Reasonable for hobby parallel-agent use; if it bites, swap `OPENROUTER_MODEL` to a paid one.

## Test plan

- [x] `python -m py_compile bot.py llm.py`
- [x] `python -m pytest -q` — 180 passed
- [ ] Manual smoke: set `LLM_BACKEND=openrouter` + a real `OPENROUTER_API_KEY` in a worktree's `.env`, run `python bot.py`, message the test bot, verify a streamed reply.
- [ ] Manual smoke: `/status` in the test bot reports `openrouter (model=...)` for the model line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)