### PR TITLE
feat: add test-writer skill + Stage 2 runner script

### DIFF
--- a/.claude/skills/test-writer/SKILL.md
+++ b/.claude/skills/test-writer/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: test-writer
+description: Stage 2 of the autonomous pipeline. FRESH session — no plan-exec rationale. Invoked headlessly by scripts/agent-test-write.sh on a state:tests-pending issue. Locates the implementation branch left by plan-exec, reads the branch diff (excluding existing test changes), writes new tests for the new code paths matching project style, runs pytest. On green commits the tests, pushes, opens or updates the PR with `Closes #<N>`, flips state:tests-pending → state:in-review. On red after self-checking that the test reflects the diff's actual behaviour, comments on the issue with the failure, flips state:tests-pending → state:needs-rework, and leaves the broken state local-only. Never modifies code outside tests/.
+version: 1.0.0
+---
+
+# test-writer
+
+Stage 2 of the issue → merged pipeline (`workflow.md`). FRESH session — you do not see plan-exec's reasoning, only the code it produced. The point: test what the code does, not what the issue asked for.
+
+## Hard boundaries
+
+You MAY:
+- Read code anywhere in the repo.
+- Edit / create files **inside `tests/`** only.
+- Run `pytest`.
+- `git add tests/...; git commit ...` (tests-only commits).
+- `git push` (only when tests are green).
+- `gh pr create` / `gh pr edit` (when tests are green).
+- Comment on the issue.
+- Flip issue labels.
+
+You MUST NOT:
+- Edit any file outside `tests/`. If the code under test is wrong, that's plan-exec's job to fix on the next cycle.
+- `gh pr merge` — Stage 3.
+- `gh issue close`.
+- `git push` when tests are red.
+- Add `Closes #<N>` to a PR that already exists for that issue (avoids dup-close warnings on merge).
+
+## The flow
+
+### 1. Locate the branch
+
+Try the PR first (rework cycles will have one open):
+
+```bash
+PR=$(gh pr list --search "Closes #<N>" --state open --json number -q '.[0].number // ""')
+if [[ -n "$PR" ]]; then
+    BRANCH=$(gh pr view "$PR" --json headRefName -q '.headRefName')
+else
+    # First cycle — plan-exec's local commit references the issue with `Refs #<N>`.
+    BRANCH=$(git log --all --grep="Refs #<N>" --format="%D" -1 \
+             | tr ',' '\n' | sed 's/^ *//' \
+             | grep -v '^HEAD' | grep -v '^origin/' \
+             | head -1)
+fi
+
+if [[ -z "$BRANCH" ]]; then
+    echo "could not locate branch for issue #<N>" >&2
+    exit 1
+fi
+
+git fetch origin "$BRANCH" 2>/dev/null || true
+git checkout "$BRANCH"
+```
+
+### 2. Read the diff
+
+```bash
+git diff main...HEAD -- ':!tests/'
+```
+
+Excluding `tests/` is deliberate. You write the tests; you do not let plan-exec's test edits anchor your judgment.
+
+### 3. Decide: do new code paths exist?
+
+If the diff is purely cosmetic (docstring, comment, whitespace), no new tests are needed — skip to step 6 and open the PR with no test commit.
+
+If the diff adds new functions, branches, error paths, or behaviour, you owe tests for them. Match the existing test style — open `tests/` and read a few files first:
+
+- One test file per source module (`test_vocab.py` covers `vocab.py`).
+- Pure helpers tested directly. Async paths use `pytest.mark.asyncio`.
+- Network / DB / Telegram are mocked or use the `httpx.MockTransport` / temp-DB patterns already in the suite.
+- One concept per test function. Test names describe the behaviour, not the function name.
+- `from __future__ import annotations` at the top of each test module.
+
+### 4. Write the tests
+
+Edit / create files in `tests/` only. Cover, in this order of priority:
+
+1. The happy path of each new public function or new code branch.
+2. One off-nominal case per error / edge condition the code introduces.
+3. Any newly added env-var or config knob — pin its default with a test.
+
+Don't over-write. A small focused test that would fail without the change is better than a sprawling one that exercises the whole module.
+
+### 5. Run pytest
+
+```bash
+source .venv/bin/activate && python -m pytest -q
+```
+
+#### Green → step 6.
+
+#### Red → self-check, then either fix-test or bounce-back.
+
+A failing test means one of:
+
+- **Your test is wrong.** Re-read the diff. Does the code actually behave the way your test asserts? If not, your assertion was based on what you assumed the code *should* do, not what it does. Fix the test, re-run.
+- **The code is wrong.** If your test correctly mirrors the diff's behaviour and still fails (e.g. it raises, returns the wrong type, breaks an existing invariant), plan-exec produced buggy code. Bounce back:
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+**Test-writer bounce-back**
+
+Stage 2 ran on branch \`<BRANCH>\` but pytest fails:
+
+\`\`\`
+<paste the last 30 lines of pytest output>
+\`\`\`
+
+I re-read the diff and confirmed the test reflects what the code actually does.
+The code looks wrong. Returning to plan-exec.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:tests-pending" \
+  --add-label "state:needs-rework"
+```
+
+Then **stop**. Do not push, do not commit failing tests. Your draft tests stay local; plan-exec will see them on the next cycle and decide whether to use them.
+
+The bar for bouncing back: *would another reasonable agent reading only the diff write the same test and see it fail?*
+
+### 6. Commit, push, open or update the PR
+
+If you wrote new tests:
+
+```bash
+git add tests/
+git commit -m "test: cover new code paths for #<N>
+
+<one-line summary of what's tested>
+
+Refs #<N>"
+```
+
+Push:
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+If a PR is **already open** (rework cycle): the push updated it. No `gh pr create`.
+
+If **no PR exists** (first cycle): open one with `Closes #<N>`:
+
+```bash
+gh pr create --base main \
+  --title "<infer from issue title or commit subject>" \
+  --body "$(cat <<'EOF'
+Closes #<N>
+
+## Summary
+<one or two lines from the issue body>
+
+## Test plan
+- [x] Stage 2 added tests for the new code paths
+- [x] \`pytest\` is green
+EOF
+)"
+```
+
+If the diff was purely cosmetic and you wrote no new tests, still push and open/update the PR. Note it in the test plan: `- [n/a] No code paths changed; existing suite still green`.
+
+### 7. Flip the label
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:tests-pending" \
+  --add-label "state:in-review"
+```
+
+### 8. Exit
+
+Print one line: `done: pushed <BRANCH> at <short-sha>, PR #<P> ready for review`.
+
+## Hard rules
+
+- **Never modify non-test files.** If the code is wrong, return to Stage 1.
+- **Never push red.** A failing test on the branch breaks Stage 3's re-run gate.
+- **One PR per issue.** If `gh pr list --search "Closes #<N>" --state open` returns a PR, push to its branch — never open a duplicate.
+- **No `Closes #<N>` on rework pushes.** The closer lives on the original PR; another `Closes #<N>` would create a dup-close warning.
+- **Don't commit local-only artefacts.** Use `git add tests/...` with explicit paths, not `git add .`.

--- a/scripts/agent-test-write.sh
+++ b/scripts/agent-test-write.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# agent-test-write.sh — Stage 2 runner for the autonomous pipeline.
+#
+# Spawns a headless Claude session with the test-writer skill loaded
+# against an issue at state:tests-pending. Validates state, dispatches,
+# logs to logs/agents/test-write-<N>-<ts>.log.
+#
+# Usage: scripts/agent-test-write.sh <issue-number>
+#
+# Exit codes:
+#   0  — claude session ran (does not imply success; check logs and labels)
+#   1  — bad arguments
+#   2  — issue not found, closed, or in unexpected state
+#   3  — required CLI missing (claude / gh / jq)
+
+set -euo pipefail
+
+# --- argument parsing ---------------------------------------------------
+
+ISSUE="${1:-}"
+if [[ -z "$ISSUE" || ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+    echo "usage: $0 <issue-number>" >&2
+    exit 1
+fi
+
+# --- dependency checks --------------------------------------------------
+
+for cmd in claude gh jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "agent-test-write: '$cmd' is required but not in PATH" >&2
+        exit 3
+    fi
+done
+
+# --- state validation ---------------------------------------------------
+
+if ! issue_json=$(gh issue view "$ISSUE" --json state,labels 2>&1); then
+    echo "agent-test-write: cannot fetch issue #$ISSUE: $issue_json" >&2
+    exit 2
+fi
+
+issue_state=$(echo "$issue_json" | jq -r '.state')
+if [[ "$issue_state" != "OPEN" ]]; then
+    echo "agent-test-write: issue #$ISSUE is $issue_state, expected OPEN" >&2
+    exit 2
+fi
+
+state_label=$(echo "$issue_json" | jq -r '[.labels[].name] | map(select(startswith("state:"))) | .[0] // ""')
+if [[ "$state_label" != "state:tests-pending" ]]; then
+    echo "agent-test-write: issue #$ISSUE is at '$state_label', expected state:tests-pending" >&2
+    exit 2
+fi
+
+# --- log paths ----------------------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+log_dir="${repo_root}/logs/agents"
+mkdir -p "$log_dir"
+ts=$(date +%Y%m%d-%H%M%S)
+log="${log_dir}/test-write-${ISSUE}-${ts}.log"
+
+# --- dispatch -----------------------------------------------------------
+
+prompt="Run the test-writer skill for issue #${ISSUE}. The implementation branch was created by plan-exec and may exist locally and/or as an open PR. Locate it before reading the diff."
+
+echo "[test-write] dispatching for issue #${ISSUE}"
+echo "[test-write] log: ${log}"
+
+# --no-session-persistence: every Stage 2 run is a fresh, blind-of-Stage-1 session.
+# --permission-mode bypassPermissions: required for headless — no human to approve prompts.
+claude -p \
+    --model claude-opus-4-7 \
+    --no-session-persistence \
+    --permission-mode bypassPermissions \
+    "$prompt" 2>&1 | tee "$log"
+
+# --- post-run summary ---------------------------------------------------
+
+echo
+echo "[test-write] final issue labels:"
+gh issue view "$ISSUE" --json labels -q '.labels[].name' | grep '^state:' || echo "  (no state label)"

--- a/tests/test_agent_test_write.py
+++ b/tests/test_agent_test_write.py
@@ -1,0 +1,76 @@
+"""Sanity checks for scripts/agent-test-write.sh.
+
+We don't shell out to a real `gh` or `claude` (those would hit live services
+and burn quota). The validation logic — argument parsing and dependency
+checks — is testable on its own, and a bash syntax check catches typos.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "agent-test-write.sh"
+
+
+def test_script_passes_bash_syntax_check() -> None:
+    bash = shutil.which("bash")
+    assert bash, "bash is required for this test"
+    result = subprocess.run(
+        [bash, "-n", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_script_is_executable() -> None:
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT.name} should be executable"
+
+
+def test_script_rejects_missing_argument() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 1, result.stderr
+    assert "usage:" in result.stderr.lower()
+
+
+def test_script_rejects_non_numeric_argument() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "not-a-number"], capture_output=True, text=True
+    )
+    assert result.returncode == 1, result.stderr
+    assert "usage:" in result.stderr.lower()
+
+
+def test_script_invokes_test_writer_skill_in_prompt() -> None:
+    text = SCRIPT.read_text()
+    assert "test-writer skill" in text
+
+
+def test_script_uses_opus_model() -> None:
+    text = SCRIPT.read_text()
+    assert "claude-opus-4-7" in text
+
+
+def test_script_uses_no_session_persistence() -> None:
+    text = SCRIPT.read_text()
+    assert "--no-session-persistence" in text
+
+
+def test_script_bypasses_permission_prompts() -> None:
+    text = SCRIPT.read_text()
+    assert "--permission-mode bypassPermissions" in text
+
+
+def test_script_writes_log_under_logs_agents() -> None:
+    text = SCRIPT.read_text()
+    assert "logs/agents" in text
+    assert "test-write-" in text
+
+
+def test_script_validates_tests_pending_state() -> None:
+    """Stage 2 only runs on state:tests-pending; mismatched state must fail."""
+    text = SCRIPT.read_text()
+    assert "state:tests-pending" in text


### PR DESCRIPTION
## Summary
Stage 2 of the autonomous pipeline (workflow.md). FRESH session — no plan-exec context. Picks up an issue at \`state:tests-pending\`.

- **\`.claude/skills/test-writer/SKILL.md\`** — playbook. Locates the implementation branch (via open PR or \`git log --grep "Refs #<N>"\`), reads the branch diff excluding \`tests/\`, writes new tests covering the new code paths, runs pytest. Hard boundary: tests-only commits.
  - **On green:** commits tests, pushes, opens PR with \`Closes #<N>\` (first cycle) or just pushes to existing PR (rework). Flips to \`state:in-review\`.
  - **On red:** self-checks — re-reads diff to decide whether the test was wrong (fixes it) or the code was wrong (bounces back to \`state:needs-rework\` with a failure comment on the issue, leaving the broken state local).
- **\`scripts/agent-test-write.sh\`** — headless runner. Same shape as \`agent-plan-exec.sh\`. Validates issue is OPEN at \`state:tests-pending\`, dispatches \`claude -p --model claude-opus-4-7 --no-session-persistence --permission-mode bypassPermissions\`. Logs to \`logs/agents/test-write-<N>-<ts>.log\`.
- **\`tests/test_agent_test_write.py\`** — 10 unit tests: bash syntax, executable bit, arg validation, prompt mentions skill, model/session/permission flags, state-label literal, log path.

## How to run
\`\`\`bash
./scripts/agent-test-write.sh 35   # picks up issue at state:tests-pending
\`\`\`

## Test plan
- [x] \`bash -n scripts/agent-test-write.sh\` passes.
- [x] \`pytest tests/test_agent_test_write.py\` — 10 passed.
- [x] Full suite: 203 passed.
- [ ] First real run after a plan-exec session — observe agent behaviour, iterate prompt if needed.

## Next
Ticket 6 — \`review-pr\` skill + \`agent-review.sh\` (Stage 3, with auto-merge + safety checks).