### PR TITLE
feat: add review-pr skill + Stage 3 runner script

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: review-pr
+description: Stage 3 of the autonomous pipeline. FRESH session. Invoked headlessly by scripts/agent-review.sh against an issue at state:in-review. Reads the issue body + Q&A comments + full PR diff (incl tests). Re-runs pytest as the merge gate. Outcomes are exactly one of three branches — APPROVE (gh pr merge --squash --delete-branch; the issue auto-closes via Closes #N), REJECT (gh pr review --request-changes with specific comments + flip issue to state:needs-rework), or BLOCK (flip to state:blocked + comment why; never merge). Block triggers are explicit in the safety checklist — secrets, CI tampering, schema risk, suspicious deps, service files, scope drift big enough to look like a different change.
+version: 1.0.0
+---
+
+# review-pr
+
+Stage 3 of the issue → merged pipeline (`workflow.md`). FRESH session. You are the last line of defense before code lands on `main` — the orchestrator merges based on your verdict.
+
+## Hard boundaries
+
+You MAY:
+- Read code, tests, the issue body, comments, the PR diff.
+- Run `pytest` (the merge gate).
+- `gh pr view` / `gh pr diff` / `gh pr review`.
+- `gh pr merge --squash --delete-branch` (only on APPROVE).
+- `gh issue comment` and `gh issue edit` (label flips).
+
+You MUST NOT:
+- Edit, write, or create any file outside `logs/`.
+- `git commit` or `git push` anything.
+- Open a new PR. Switch branches arbitrarily.
+- Approve when pytest is red.
+- Approve when the safety checklist trips.
+- Re-run a stage's work (you are not Stage 1 or 2).
+
+## The flow
+
+### 1. Resolve the PR for the issue
+
+```bash
+PR=$(gh pr list --search "Closes #<N>" --state open --json number -q '.[0].number // ""')
+if [[ -z "$PR" ]]; then
+    echo "no open PR found for issue #<N>" >&2
+    exit 1
+fi
+```
+
+If multiple open PRs reference the issue, that's a bug — comment on the issue, flip to `state:blocked`, and exit. Do not merge any of them.
+
+### 2. Read everything
+
+```bash
+gh issue view <N> --json title,body,comments
+gh pr view "$PR" --json title,body,headRefName,baseRefName,additions,deletions,changedFiles
+gh pr diff "$PR"
+```
+
+Capture: the issue's intent (body + clarification Q&A), what the PR claims to do (title + body), and the full diff.
+
+### 3. Switch to the PR branch and re-run pytest
+
+```bash
+BRANCH=$(gh pr view "$PR" --json headRefName -q '.headRefName')
+git fetch origin "$BRANCH"
+git checkout "$BRANCH" && git pull --ff-only
+source .venv/bin/activate && python -m pytest -q
+```
+
+If pytest is **red**, this is an automatic REJECT — Stage 2 should not have pushed red. Skip to step 5 (REJECT) with the failure as the rework reason.
+
+### 4. Run the safety checklist
+
+For each trigger below, scan the diff. Any single hit → BLOCK (skip to step 6). Multiple unrelated triggers → still BLOCK; one comment listing all of them.
+
+- **Secrets / credentials.** API keys, OAuth tokens, passwords, `Bearer` headers with literal values, JWT tokens, `.pem` keys, hard-coded `.env` values. Look for high-entropy strings ≥ 20 chars in non-test code, `Authorization: ` headers in code, anything matching `[A-Za-z0-9_-]{40,}` adjacent to `key`/`token`/`secret`. False positives are acceptable cost — block and let the user clear.
+- **CI / workflow tampering.** Any change under `.github/workflows/**`. New action that fetches arbitrary URLs, disables a check, alters `permissions:` block, or adds a new secret reference. Block on any non-trivial change here; tiny changes (e.g. version bump in an existing pinned action) are still worth a human eye.
+- **Schema / data-loss risk.** Changes to `db.py` that drop columns, alter primary keys, change foreign-key cascades, or modify FSRS columns (`stability`, `difficulty`, `state`, `step`, `due`, `reps`, `lapses`, `last_review`). Adding a column is fine; removing or rewriting one is not.
+- **Dependency additions.** New entries in `requirements.txt`. Verify the package name is the canonical one (no typo-squatting — e.g. `python-telegrm-bot` is wrong). Verify version pinning is present. If unfamiliar, block and ask the user to vet.
+- **Service / install scripts.** Any change to `gemma-rpi-agent.service` or `install-service.sh`. These run on the live Pi; humans should eyeball.
+- **Scope drift.** PR diff is materially larger than the issue body suggests, OR touches modules unrelated to the issue. Examples: issue says "fix typo in /help text" but PR refactors three modules. This is REJECT (rework, scope reduction), not BLOCK — unless the unrelated changes themselves trip a safety trigger.
+
+### 5. Run the quality checklist
+
+These are REJECT conditions (recoverable rework, not block):
+
+- **Test coverage.** New code paths in non-test files without corresponding test additions. Exception: pure docstring/comment/whitespace changes; rename of a private helper; doc-only edits.
+- **`dev-flow` compliance.** Branch prefix matches the issue's `type:*` label. New env-var added to `.env.example` and the env table in `CLAUDE.md`. No new comments that just narrate what well-named code already says.
+- **Issue scope.** PR addresses what the issue actually asked for. Cross-reference the issue body's exit criteria (if any) against the diff's behaviour.
+- **Module conventions.** Logic lives in `vocab.py`/`llm.py`/`scheduler.py`/etc., not in `bot.py`. Pure helpers don't open HTTP clients or hit SQLite — they take dependencies as arguments. (See `compute_weight`, `plan_push_times`, `_parse_sse_delta` for the pattern.)
+- **Test quality.** New tests actually exercise the new behaviour (would fail without the change). No tests that just call the function and `assert True`.
+
+### 6. Decide the outcome — exactly one of three
+
+#### APPROVE — merge
+
+```bash
+gh pr review "$PR" --approve --body "Stage 3 review passed. Merging."
+gh pr merge "$PR" --squash --delete-branch
+gh issue edit <N> --remove-label "state:in-review"
+```
+
+The squash-merge closes the issue automatically (via `Closes #<N>` in the PR body). The label removal is belt-and-braces in case GitHub flakes.
+
+After merge, print: `merged: PR #<P> for issue #<N>; branch deleted`.
+
+#### REJECT — rework cycle
+
+```bash
+gh pr review "$PR" --request-changes --body "$(cat <<'EOF'
+**Stage 3 — needs-rework**
+
+<one-paragraph summary of what's wrong>
+
+Specifics:
+- <bullet 1: file:line — what to change and why>
+- <bullet 2>
+- ...
+
+Returning to plan-exec for the next cycle.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:in-review" \
+  --add-label "state:needs-rework"
+```
+
+Print: `rework: PR #<P> bounced for issue #<N>`.
+
+#### BLOCK — needs human attention
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+**Stage 3 — blocked**
+
+Reviewer halted auto-merge for the following reason(s):
+
+- <trigger 1: file:line — concrete description, e.g. "API key literal in llm.py:42">
+- <trigger 2 if any>
+
+This needs a human to decide. Once resolved, re-label to \`state:in-review\` to retry, or to \`state:needs-rework\` to send back to plan-exec.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:in-review" \
+  --add-label "state:blocked"
+```
+
+Do **not** also leave a PR review — block is for the user, not the bot. Print: `blocked: PR #<P> for issue #<N>; reason posted on issue`.
+
+### 7. Exit
+
+After whichever branch, exit. Do not loop.
+
+## How the three outcomes differ
+
+|  | APPROVE | REJECT | BLOCK |
+|---|---|---|---|
+| pytest | green | red OR green-but-flawed | green or red — orthogonal |
+| Safety checklist | clean | clean | tripped |
+| Quality checklist | clean | tripped | orthogonal |
+| Action | merge + delete branch | request-changes review + flip needs-rework | issue comment + flip blocked |
+| Pipeline next step | issue closed | plan-exec rework cycle | human |
+
+If two outcomes seem to apply (e.g. red pytest **and** secret in diff), choose **BLOCK** — it's the more conservative call, and the human resolution covers both issues.
+
+## What you must NOT do
+
+- Suggest code in a review comment when the right call is BLOCK or REJECT. You don't write code in this stage.
+- Approve a PR with red pytest "because the failure looks unrelated". Pytest is the gate; flakes are the user's problem to triage by re-running the script.
+- Re-run pytest more than once trying to get green. Flake-hunting belongs to plan-exec / test-writer, not Stage 3.
+- Leave the issue at `state:in-review` after deciding. Always flip exactly once.
+- Merge with a different strategy (`--merge` / `--rebase`). The pipeline assumes squash so each issue maps to one main commit.

--- a/scripts/agent-review.sh
+++ b/scripts/agent-review.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# agent-review.sh — Stage 3 runner for the autonomous pipeline.
+#
+# Spawns a headless Claude session with the review-pr skill loaded
+# against an issue at state:in-review. Resolves the PR from the issue,
+# validates state, dispatches. Logs to logs/agents/review-<N>-<ts>.log.
+#
+# Usage: scripts/agent-review.sh <issue-number>
+#
+# Exit codes:
+#   0  — claude session ran (does not imply outcome; check logs and labels)
+#   1  — bad arguments
+#   2  — issue not found, closed, or in unexpected state
+#   3  — required CLI missing (claude / gh / jq)
+#   4  — no open PR found for the issue (pipeline is in an inconsistent state)
+
+set -euo pipefail
+
+# --- argument parsing ---------------------------------------------------
+
+ISSUE="${1:-}"
+if [[ -z "$ISSUE" || ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+    echo "usage: $0 <issue-number>" >&2
+    exit 1
+fi
+
+# --- dependency checks --------------------------------------------------
+
+for cmd in claude gh jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "agent-review: '$cmd' is required but not in PATH" >&2
+        exit 3
+    fi
+done
+
+# --- state validation ---------------------------------------------------
+
+if ! issue_json=$(gh issue view "$ISSUE" --json state,labels 2>&1); then
+    echo "agent-review: cannot fetch issue #$ISSUE: $issue_json" >&2
+    exit 2
+fi
+
+issue_state=$(echo "$issue_json" | jq -r '.state')
+if [[ "$issue_state" != "OPEN" ]]; then
+    echo "agent-review: issue #$ISSUE is $issue_state, expected OPEN" >&2
+    exit 2
+fi
+
+state_label=$(echo "$issue_json" | jq -r '[.labels[].name] | map(select(startswith("state:"))) | .[0] // ""')
+if [[ "$state_label" != "state:in-review" ]]; then
+    echo "agent-review: issue #$ISSUE is at '$state_label', expected state:in-review" >&2
+    exit 2
+fi
+
+# --- PR resolution (early so we fail fast if the pipeline is inconsistent) ---
+
+pr_number=$(gh pr list --search "Closes #${ISSUE}" --state open --json number -q '.[0].number // ""')
+if [[ -z "$pr_number" ]]; then
+    echo "agent-review: no open PR found for issue #${ISSUE} (search 'Closes #${ISSUE}')" >&2
+    exit 4
+fi
+
+# --- log paths ----------------------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+log_dir="${repo_root}/logs/agents"
+mkdir -p "$log_dir"
+ts=$(date +%Y%m%d-%H%M%S)
+log="${log_dir}/review-${ISSUE}-${ts}.log"
+
+# --- dispatch -----------------------------------------------------------
+
+prompt="Run the review-pr skill for issue #${ISSUE}. The PR is #${pr_number}. Decide exactly one of APPROVE / REJECT / BLOCK per the skill's checklist."
+
+echo "[review] dispatching for issue #${ISSUE} (PR #${pr_number})"
+echo "[review] log: ${log}"
+
+# --no-session-persistence: every Stage 3 run is a fresh, isolated session.
+# --permission-mode bypassPermissions: required for headless — no human to approve prompts.
+claude -p \
+    --model claude-opus-4-7 \
+    --no-session-persistence \
+    --permission-mode bypassPermissions \
+    "$prompt" 2>&1 | tee "$log"
+
+# --- post-run summary ---------------------------------------------------
+
+echo
+echo "[review] final issue state:"
+issue_after=$(gh issue view "$ISSUE" --json state,labels 2>&1 || echo '{"state":"UNKNOWN"}')
+echo "  state: $(echo "$issue_after" | jq -r '.state')"
+echo "  labels: $(echo "$issue_after" | jq -r '[.labels[].name | select(startswith("state:"))] | join(", ") // "(none)"')"
+echo "[review] final PR state:"
+gh pr view "$pr_number" --json state,mergedAt -q '"  state: " + .state + (if .mergedAt then ", merged at " + .mergedAt else "" end)' 2>&1 || true

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -1,0 +1,89 @@
+"""Sanity checks for scripts/agent-review.sh.
+
+We don't shell out to a real `gh` or `claude` (those would hit live services
+and burn quota). The validation logic — argument parsing and dependency
+checks — is testable on its own, and a bash syntax check catches typos.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "agent-review.sh"
+
+
+def test_script_passes_bash_syntax_check() -> None:
+    bash = shutil.which("bash")
+    assert bash, "bash is required for this test"
+    result = subprocess.run(
+        [bash, "-n", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_script_is_executable() -> None:
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT.name} should be executable"
+
+
+def test_script_rejects_missing_argument() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 1, result.stderr
+    assert "usage:" in result.stderr.lower()
+
+
+def test_script_rejects_non_numeric_argument() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "not-a-number"], capture_output=True, text=True
+    )
+    assert result.returncode == 1, result.stderr
+    assert "usage:" in result.stderr.lower()
+
+
+def test_script_invokes_review_pr_skill_in_prompt() -> None:
+    text = SCRIPT.read_text()
+    assert "review-pr skill" in text
+
+
+def test_script_uses_opus_model() -> None:
+    text = SCRIPT.read_text()
+    assert "claude-opus-4-7" in text
+
+
+def test_script_uses_no_session_persistence() -> None:
+    text = SCRIPT.read_text()
+    assert "--no-session-persistence" in text
+
+
+def test_script_bypasses_permission_prompts() -> None:
+    text = SCRIPT.read_text()
+    assert "--permission-mode bypassPermissions" in text
+
+
+def test_script_writes_log_under_logs_agents() -> None:
+    text = SCRIPT.read_text()
+    assert "logs/agents" in text
+    assert "review-" in text
+
+
+def test_script_validates_in_review_state() -> None:
+    """Stage 3 only runs on state:in-review."""
+    text = SCRIPT.read_text()
+    assert "state:in-review" in text
+
+
+def test_script_resolves_pr_via_closes_search() -> None:
+    """Stage 3 finds the PR by 'Closes #<N>' search before dispatching."""
+    text = SCRIPT.read_text()
+    assert "gh pr list --search" in text
+    assert "Closes #" in text
+
+
+def test_script_passes_pr_number_to_agent() -> None:
+    """The agent prompt must reference both the issue and PR numbers."""
+    text = SCRIPT.read_text()
+    assert "PR is #" in text or "PR #${pr_number}" in text or "PR is #${pr_number}" in text


### PR DESCRIPTION
## Summary
Stage 3 of the autonomous pipeline (workflow.md). FRESH session. Picks up an issue at \`state:in-review\`, reads issue + Q&A + PR diff, re-runs pytest, decides exactly one of three outcomes.

- **\`.claude/skills/review-pr/SKILL.md\`** — the playbook with explicit triage:
  - **APPROVE:** \`gh pr review --approve\` → \`gh pr merge --squash --delete-branch\`. Issue auto-closes via \`Closes #N\`.
  - **REJECT:** \`gh pr review --request-changes\` with bullets → flip to \`state:needs-rework\`. Plan-exec picks up review comments next cycle.
  - **BLOCK:** comment on issue → flip to \`state:blocked\`. Reserved for safety triggers (secrets, CI tampering, schema risk, suspicious deps, service files, big scope drift).
- **Quality checklist** (REJECT): test coverage, dev-flow compliance, scope match, module conventions, test quality.
- **Safety checklist** (BLOCK): secrets/credentials, \`.github/workflows/**\` changes, \`db.py\` destructive migrations / FSRS column edits, \`requirements.txt\` additions (typo-squat / unpinned), service / install scripts, scope drift big enough to look like a different change.
- **Hard boundary:** read-only on code. No \`git commit\`, no \`git push\`, no new PRs.
- **\`scripts/agent-review.sh\`** — runner that resolves the PR via \`gh pr list --search "Closes #<N>"\` BEFORE dispatching; exits with code 4 if no open PR is found (pipeline inconsistency caught early).
- **\`tests/test_agent_review.py\`** — 12 unit tests including PR-resolution logic and the prompt mentions both issue and PR numbers.

## Conflict resolution policy
If two outcomes seem to apply (e.g. red pytest + secret in diff), the skill prescribes BLOCK — more conservative, human resolves both.

## How to run
\`\`\`bash
./scripts/agent-review.sh 35   # picks up issue at state:in-review
\`\`\`

## Test plan
- [x] \`bash -n scripts/agent-review.sh\` passes.
- [x] \`pytest tests/test_agent_review.py\` — 12 passed.
- [x] Full suite: 215 passed.
- [ ] First real run after a test-writer session — observe agent behaviour, iterate prompt if needed.

## Pipeline now end-to-end (manual)
\`\`\`
state:needs-planning  →  ./scripts/agent-plan-exec.sh <N>
state:tests-pending   →  ./scripts/agent-test-write.sh <N>
state:in-review       →  ./scripts/agent-review.sh <N>
\`\`\`

## Next
Ticket 7 — \`orchestrator.sh\` + systemd unit. Polls labels, dispatches the right script, handles cycle counter + trust gate. Don't start until you've exercised these three scripts on a real issue.