### PR TITLE
fix: plan-exec accepts unlabelled (fresh) issues

### DIFF
--- a/.claude/skills/plan-exec/SKILL.md
+++ b/.claude/skills/plan-exec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-exec
-description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue at state:needs-planning or state:needs-rework. Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
+description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue that is unlabelled (fresh) or at state:needs-planning or state:needs-rework. Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
 version: 1.0.0
 ---
 
@@ -40,7 +40,12 @@ PR=$(gh pr list --search "Closes #<N>" --state all --json number -q '.[0].number
 
 ### 2. Verify state and flip to in-progress
 
-The label MUST already be `state:needs-planning` or `state:needs-rework` (the runner script enforces this; double-check). Flip:
+The valid starting states are:
+- **unlabelled** — fresh issue, never picked up. Treat exactly like `state:needs-planning`. The runner script accepts this as the equivalent of "fresh".
+- `state:needs-planning` — explicitly labelled fresh.
+- `state:needs-rework` — coming back from a Stage-2 bounce or Stage-3 rejection.
+
+The runner script enforces these are the only inputs; double-check anyway. Flip to in-progress:
 
 ```bash
 gh issue edit <N> \
@@ -48,7 +53,7 @@ gh issue edit <N> \
   --add-label "state:in-progress"
 ```
 
-`gh` silently ignores `--remove-label` for labels not present.
+`gh` silently ignores `--remove-label` for labels not present, so the same command works whether the issue was unlabelled, `state:needs-planning`, or `state:needs-rework`.
 
 ### 3. Decide: clarify or proceed?
 

--- a/scripts/agent-plan-exec.sh
+++ b/scripts/agent-plan-exec.sh
@@ -47,14 +47,12 @@ fi
 
 state_label=$(echo "$issue_json" | jq -r '[.labels[].name] | map(select(startswith("state:"))) | .[0] // ""')
 case "$state_label" in
-    state:needs-planning|state:needs-rework)
-        ;;
-    "")
-        echo "agent-plan-exec: issue #$ISSUE has no state:* label" >&2
-        exit 2
+    ""|state:needs-planning|state:needs-rework)
+        # Empty state label is a fresh issue — plan-exec applies state:needs-planning
+        # itself as part of the initial flip. No auto-labelling exists at file-time.
         ;;
     *)
-        echo "agent-plan-exec: issue #$ISSUE is at '$state_label', expected state:needs-planning or state:needs-rework" >&2
+        echo "agent-plan-exec: issue #$ISSUE is at '$state_label', expected unset, state:needs-planning, or state:needs-rework" >&2
         exit 2
         ;;
 esac
@@ -69,9 +67,9 @@ log="${log_dir}/plan-exec-${ISSUE}-${ts}.log"
 
 # --- dispatch -----------------------------------------------------------
 
-prompt="Run the plan-exec skill for issue #${ISSUE}. Current state label: ${state_label}."
+prompt="Run the plan-exec skill for issue #${ISSUE}. Current state: ${state_label:-unlabelled (fresh issue — apply state:needs-planning before flipping to in-progress)}."
 
-echo "[plan-exec] dispatching for issue #${ISSUE} (state=${state_label})"
+echo "[plan-exec] dispatching for issue #${ISSUE} (state=${state_label:-unlabelled})"
 echo "[plan-exec] log: ${log}"
 
 # --no-session-persistence: each run is a fresh, unrecoverable session.

--- a/tests/test_agent_plan_exec.py
+++ b/tests/test_agent_plan_exec.py
@@ -75,3 +75,11 @@ def test_script_writes_log_under_logs_agents() -> None:
     text = SCRIPT.read_text()
     assert "logs/agents" in text
     assert "plan-exec-" in text
+
+
+def test_script_accepts_unlabelled_fresh_issues() -> None:
+    """Fresh issues (no state:* label) are valid Stage 1 input — the agent
+    applies state:needs-planning itself as part of the initial flip."""
+    text = SCRIPT.read_text()
+    # The case statement must include "" as a valid starting state.
+    assert '""|state:needs-planning|state:needs-rework' in text

--- a/workflow.md
+++ b/workflow.md
@@ -76,13 +76,15 @@ The full label set lives in `scripts/setup-labels.sh` (idempotent — safe to re
 
 | Label | Set by | Means |
 |---|---|---|
-| `state:needs-planning` | user (default on new issue) | Untouched. Stage 1 will pick this up. |
+| `state:needs-planning` | user (or implicit — fresh unlabelled issues are treated as if they had this) | Untouched. Stage 1 will pick this up. |
 | `state:in-progress` | Stage 1 (plan-exec, at start) | Plan-exec is working. |
 | `state:clarification-needed` | Stage 1 (clarify-issue) | **HUMAN GATE.** Question posted, waiting on user. Orchestrator skips. |
 | `state:tests-pending` | Stage 1 (at end, after commit) | Branch + commit ready, awaiting test-writer. |
 | `state:in-review` | Stage 2 (after tests green + PR opened) | Reviewer's turn. |
 | `state:needs-rework` | Stage 2 (test failure) or Stage 3 (review failure) | Back to Stage 1. |
 | `state:blocked` | Stage 3 or anyone manually | Stop. **HUMAN GATE.** Park reason in comment. |
+
+**Fresh issues are unlabelled.** New issues filed without any `state:*` label are treated as equivalent to `state:needs-planning` — Stage 1 (plan-exec) accepts them and applies the label as part of its initial flip to `state:in-progress`. The user does not need to manually label new issues.
 
 ### Type, priority, area (unchanged)
 


### PR DESCRIPTION
## Summary
A new GitHub issue carries no \`state:*\` label until something applies one. The previous Stage 1 guard rejected those (\`agent-plan-exec: issue #N has no state:* label\`), forcing manual labelling for every fresh issue.

Now plan-exec treats unlabelled issues as equivalent to \`state:needs-planning\` — the existing flip command already handles it correctly (gh silently ignores \`--remove-label\` for missing labels), so the agent applies \`state:in-progress\` cleanly without any extra branch.

## Changes
- **\`scripts/agent-plan-exec.sh\`** — case statement now accepts \`""\` (empty) alongside \`state:needs-planning\` and \`state:needs-rework\`. The dispatch prompt and console line surface \`unlabelled (fresh issue)\` so the log makes the path obvious.
- **\`.claude/skills/plan-exec/SKILL.md\`** — section 2 enumerates the three valid starting states and explains why one flip command covers all three.
- **\`workflow.md\`** — adds a note that fresh unlabelled issues flow through Stage 1 without manual labelling. \`state:needs-planning\` row now reads "user (or implicit — fresh unlabelled issues are treated as if they had this)".
- **\`tests/test_agent_plan_exec.py\`** — adds \`test_script_accepts_unlabelled_fresh_issues\` pinning the case-statement literal.

## Test plan
- [x] \`bash -n scripts/agent-plan-exec.sh\` passes.
- [x] \`pytest tests/test_agent_plan_exec.py\` — 10 passed (was 9).
- [x] Full suite: 216 passed.
- [ ] On the VPS: \`./scripts/agent-plan-exec.sh 35\` against an unlabelled #35 should now dispatch instead of erroring.