### PR TITLE
fix: opt agent scripts into IS_SANDBOX=1 for root execution

### DIFF
--- a/scripts/agent-plan-exec.sh
+++ b/scripts/agent-plan-exec.sh
@@ -74,7 +74,9 @@ echo "[plan-exec] log: ${log}"
 
 # --no-session-persistence: each run is a fresh, unrecoverable session.
 # --permission-mode bypassPermissions: required for headless — no human to approve prompts.
-claude -p \
+# IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
+# under root by default; the env var opts in for sandboxed VPS / container hosts.
+IS_SANDBOX=1 claude -p \
     --model claude-opus-4-7 \
     --no-session-persistence \
     --permission-mode bypassPermissions \

--- a/scripts/agent-review.sh
+++ b/scripts/agent-review.sh
@@ -77,7 +77,9 @@ echo "[review] log: ${log}"
 
 # --no-session-persistence: every Stage 3 run is a fresh, isolated session.
 # --permission-mode bypassPermissions: required for headless — no human to approve prompts.
-claude -p \
+# IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
+# under root by default; the env var opts in for sandboxed VPS / container hosts.
+IS_SANDBOX=1 claude -p \
     --model claude-opus-4-7 \
     --no-session-persistence \
     --permission-mode bypassPermissions \

--- a/scripts/agent-test-write.sh
+++ b/scripts/agent-test-write.sh
@@ -68,7 +68,9 @@ echo "[test-write] log: ${log}"
 
 # --no-session-persistence: every Stage 2 run is a fresh, blind-of-Stage-1 session.
 # --permission-mode bypassPermissions: required for headless — no human to approve prompts.
-claude -p \
+# IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
+# under root by default; the env var opts in for sandboxed VPS / container hosts.
+IS_SANDBOX=1 claude -p \
     --model claude-opus-4-7 \
     --no-session-persistence \
     --permission-mode bypassPermissions \

--- a/tests/test_agent_plan_exec.py
+++ b/tests/test_agent_plan_exec.py
@@ -70,6 +70,13 @@ def test_script_bypasses_permission_prompts() -> None:
     assert "--permission-mode bypassPermissions" in text
 
 
+def test_script_opts_into_sandbox_for_root() -> None:
+    """claude refuses bypassPermissions under root unless IS_SANDBOX=1
+    is set in the environment of the claude invocation."""
+    text = SCRIPT.read_text()
+    assert "IS_SANDBOX=1 claude -p" in text
+
+
 def test_script_writes_log_under_logs_agents() -> None:
     """Log location convention used by the orchestrator."""
     text = SCRIPT.read_text()

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -64,6 +64,13 @@ def test_script_bypasses_permission_prompts() -> None:
     assert "--permission-mode bypassPermissions" in text
 
 
+def test_script_opts_into_sandbox_for_root() -> None:
+    """claude refuses bypassPermissions under root unless IS_SANDBOX=1
+    is set in the environment of the claude invocation."""
+    text = SCRIPT.read_text()
+    assert "IS_SANDBOX=1 claude -p" in text
+
+
 def test_script_writes_log_under_logs_agents() -> None:
     text = SCRIPT.read_text()
     assert "logs/agents" in text

--- a/tests/test_agent_test_write.py
+++ b/tests/test_agent_test_write.py
@@ -64,6 +64,13 @@ def test_script_bypasses_permission_prompts() -> None:
     assert "--permission-mode bypassPermissions" in text
 
 
+def test_script_opts_into_sandbox_for_root() -> None:
+    """claude refuses bypassPermissions under root unless IS_SANDBOX=1
+    is set in the environment of the claude invocation."""
+    text = SCRIPT.read_text()
+    assert "IS_SANDBOX=1 claude -p" in text
+
+
 def test_script_writes_log_under_logs_agents() -> None:
     text = SCRIPT.read_text()
     assert "logs/agents" in text


### PR DESCRIPTION
## Summary
Claude Code refuses \`--dangerously-skip-permissions\` (which \`--permission-mode bypassPermissions\` maps to) when the effective UID is 0 — a defense against agents accidentally running with root privileges. The official override is \`IS_SANDBOX=1\`, which acknowledges the host is a dedicated sandbox.

Without the env var, dispatching any agent script from a root shell fails:

\`\`\`
[plan-exec] log: /root/.../logs/agents/plan-exec-35-20260429-212641.log
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
\`\`\`

This was hit on a GitHub Actions runner / VPS combination where the user is operating as root.

## Changes
- \`scripts/agent-plan-exec.sh\`, \`scripts/agent-test-write.sh\`, \`scripts/agent-review.sh\` — prefix the \`claude -p\` invocation with \`IS_SANDBOX=1\`. Per-invocation scoping keeps the var out of the broader shell environment.
- Comment block above each invocation documents why.
- \`tests/test_agent_plan_exec.py\`, \`tests/test_agent_test_write.py\`, \`tests/test_agent_review.py\` — new \`test_script_opts_into_sandbox_for_root\` pinning the literal so the prefix doesn't regress.

## Test plan
- [x] \`bash -n\` on all three scripts.
- [x] All three \`tests/test_agent_*.py\` files: 35 passed.
- [x] Pre-existing flaky \`test_schedule_chat_is_idempotent\` (#37 backlog) — passes alone, unrelated to this change.
- [ ] On VPS (root): \`./scripts/agent-plan-exec.sh 35\` should now dispatch instead of erroring on the permission check.

## Note
\`IS_SANDBOX=1\` is the soft-guard override — it doesn't make root + bypass-permissions safe, only acknowledged. The recommended deployment posture is still a non-root user (\`gemma\`/\`agent\`/etc.) with sudo for system packages only. The env var is the path of least resistance for VPS / container hosts where root is the working shell.