### PR TITLE
chore: highlight vocab matches with <code> instead of <b>

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -222,7 +222,7 @@ async def dispatch_push(chat_id: int) -> None:
         ]]
     )
     chat_words = [r["text"] for r in vocab.list_words(conn, chat_id)]
-    formatted = vocab.bold_matches(text, chat_words)
+    formatted = vocab.highlight_matches(text, chat_words)
     try:
         msg = await app.bot.send_message(
             chat_id=chat_id, text=formatted, reply_markup=kb, parse_mode="HTML"
@@ -521,12 +521,12 @@ async def on_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not explanation:
         return
     chat_id = update.effective_chat.id
-    # Reuse the rated word's text for the transcript tag and to bold it inline.
+    # Reuse the rated word's text for the transcript tag and to highlight it inline.
     row = conn.execute(
         "SELECT text FROM words WHERE id = ?", (word_id,)
     ).fetchone()
     tag_word = row["text"] if row is not None else "?"
-    formatted = vocab.bold_matches(
+    formatted = vocab.highlight_matches(
         explanation, [tag_word] if row is not None else []
     )
 
@@ -661,7 +661,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     last_edit = asyncio.get_event_loop().time()
 
     def fmt(s: str) -> str:
-        return vocab.bold_matches(s, word_texts)
+        return vocab.highlight_matches(s, word_texts)
 
     try:
         async for token in llm.stream_chat(histories[chat_id]):

--- a/scheduler.py
+++ b/scheduler.py
@@ -185,7 +185,7 @@ def format_explanation_reply(
 ) -> str:
     """Compose the ❌-forgot reply body — explanation, then optional translation.
 
-    `explanation_html` is already HTML-safe (typically from `vocab.bold_matches`).
+    `explanation_html` is already HTML-safe (typically from `vocab.highlight_matches`).
     `translation` is plain text and gets HTML-escaped here. When translation is
     None or empty the reply is just the explanation, unchanged.
     """

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -121,63 +121,66 @@ def test_scan_mentions_empty_inputs() -> None:
     assert vocab.scan_mentions("", [(1, "hello")]) == []
 
 
-def test_bold_matches_empty_text() -> None:
-    assert vocab.bold_matches("", ["foo"]) == ""
+def test_highlight_matches_empty_text() -> None:
+    assert vocab.highlight_matches("", ["foo"]) == ""
 
 
-def test_bold_matches_no_words_just_escapes() -> None:
-    assert vocab.bold_matches("a < b & c", []) == "a &lt; b &amp; c"
+def test_highlight_matches_no_words_just_escapes() -> None:
+    assert vocab.highlight_matches("a < b & c", []) == "a &lt; b &amp; c"
 
 
-def test_bold_matches_wraps_substring_case_insensitive() -> None:
-    out = vocab.bold_matches("It was Serendipity, brief.", ["serendipity"])
-    assert out == "It was <b>Serendipity</b>, brief."
+def test_highlight_matches_wraps_substring_case_insensitive() -> None:
+    out = vocab.highlight_matches("It was Serendipity, brief.", ["serendipity"])
+    assert out == "It was <code>Serendipity</code>, brief."
 
 
-def test_bold_matches_escapes_html_chars_outside_match() -> None:
-    out = vocab.bold_matches("<cat> & dog", ["cat"])
-    assert out == "&lt;<b>cat</b>&gt; &amp; dog"
+def test_highlight_matches_escapes_html_chars_outside_match() -> None:
+    out = vocab.highlight_matches("<cat> & dog", ["cat"])
+    assert out == "&lt;<code>cat</code>&gt; &amp; dog"
 
 
-def test_bold_matches_longer_word_wins_on_overlap() -> None:
-    out = vocab.bold_matches("concatenate things", ["cat", "concatenate"])
-    assert out == "<b>concatenate</b> things"
+def test_highlight_matches_longer_word_wins_on_overlap() -> None:
+    out = vocab.highlight_matches("concatenate things", ["cat", "concatenate"])
+    assert out == "<code>concatenate</code> things"
 
 
-def test_bold_matches_multiple_non_overlapping() -> None:
-    out = vocab.bold_matches("cat dog cat", ["cat", "dog"])
-    assert out == "<b>cat</b> <b>dog</b> <b>cat</b>"
+def test_highlight_matches_multiple_non_overlapping() -> None:
+    out = vocab.highlight_matches("cat dog cat", ["cat", "dog"])
+    assert out == "<code>cat</code> <code>dog</code> <code>cat</code>"
 
 
-def test_bold_matches_phrase() -> None:
-    out = vocab.bold_matches("She did it on the fly today.", ["on the fly"])
-    assert out == "She did it <b>on the fly</b> today."
+def test_highlight_matches_phrase() -> None:
+    out = vocab.highlight_matches("She did it on the fly today.", ["on the fly"])
+    assert out == "She did it <code>on the fly</code> today."
 
 
-def test_bold_matches_ignores_empty_word_entries() -> None:
-    assert vocab.bold_matches("hello world", ["", "world"]) == "hello <b>world</b>"
+def test_highlight_matches_ignores_empty_word_entries() -> None:
+    assert (
+        vocab.highlight_matches("hello world", ["", "world"])
+        == "hello <code>world</code>"
+    )
 
 
-def test_bold_matches_strips_markdown_bold_around_vocab_word() -> None:
-    out = vocab.bold_matches(
+def test_highlight_matches_strips_markdown_bold_around_vocab_word() -> None:
+    out = vocab.highlight_matches(
         "It's a testament to **strength** today.", ["strength"]
     )
-    assert out == "It&#x27;s a testament to <b>strength</b> today."
+    assert out == "It&#x27;s a testament to <code>strength</code> today."
 
 
-def test_bold_matches_strips_markdown_bold_when_word_not_in_vocab() -> None:
-    out = vocab.bold_matches("truly **remarkable** indeed", [])
+def test_highlight_matches_strips_markdown_bold_when_word_not_in_vocab() -> None:
+    out = vocab.highlight_matches("truly **remarkable** indeed", [])
     assert out == "truly remarkable indeed"
 
 
-def test_bold_matches_strips_underscore_markdown_bold() -> None:
-    out = vocab.bold_matches("__placid__ waters", ["placid"])
-    assert out == "<b>placid</b> waters"
+def test_highlight_matches_strips_underscore_markdown_bold() -> None:
+    out = vocab.highlight_matches("__placid__ waters", ["placid"])
+    assert out == "<code>placid</code> waters"
 
 
-def test_bold_matches_handles_multiple_markdown_chunks() -> None:
-    out = vocab.bold_matches("**alpha** then **beta** end", ["beta"])
-    assert out == "alpha then <b>beta</b> end"
+def test_highlight_matches_handles_multiple_markdown_chunks() -> None:
+    out = vocab.highlight_matches("**alpha** then **beta** end", ["beta"])
+    assert out == "alpha then <code>beta</code> end"
 
 
 def test_bump_mentions_increments_and_timestamps(conn: sqlite3.Connection) -> None:

--- a/vocab.py
+++ b/vocab.py
@@ -147,15 +147,15 @@ def scan_mentions(text: str, words: list[tuple[int, str]]) -> list[int]:
 _MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*|__(.+?)__", re.DOTALL)
 
 
-def bold_matches(text: str, words: list[str]) -> str:
-    """HTML-escape `text` and wrap any vocab-word substrings in <b>…</b>.
+def highlight_matches(text: str, words: list[str]) -> str:
+    """HTML-escape `text` and wrap any vocab-word substrings in <code>…</code>.
 
     Mirrors `scan_mentions`'s case-insensitive substring match. When two
     candidate words would overlap (e.g. "cat" inside "concatenate") the
-    longer one wins, so we never bold a fragment of a longer match. Markdown
-    bold markers (`**x**` / `__x__`) the model sometimes emits are stripped
-    first — Telegram's HTML mode would otherwise render them literally.
-    Returns a string safe to send with Telegram's HTML parse mode.
+    longer one wins, so we never highlight a fragment of a longer match.
+    Markdown bold markers (`**x**` / `__x__`) the model sometimes emits are
+    stripped first — Telegram's HTML mode would otherwise render them
+    literally. Returns a string safe to send with Telegram's HTML parse mode.
     """
     if not text:
         return ""
@@ -178,9 +178,9 @@ def bold_matches(text: str, words: list[str]) -> str:
     cursor = 0
     for s, e in spans:
         out.append(html.escape(text[cursor:s]))
-        out.append("<b>")
+        out.append("<code>")
         out.append(html.escape(text[s:e]))
-        out.append("</b>")
+        out.append("</code>")
         cursor = e
     out.append(html.escape(text[cursor:]))
     return "".join(out)


### PR DESCRIPTION
Closes #35

## Summary
Vocab-word matches in pushes, ❌-forgot replies, and live-chat streaming are now wrapped in Telegram's HTML `<code>` tag instead of `<b>`. `<code>` renders as monospaced text, which stands out more clearly in the Telegram UI than bold.

The function `vocab.bold_matches` is renamed to `vocab.highlight_matches`; all three `bot.py` call sites and the `scheduler.py` docstring are updated.

## Test plan
- [x] `pytest` is green (219 passed)
- [n/a] No new code paths added; the existing `vocab.highlight_matches` tests (renamed from `bold_matches`) cover the new tag — escape handling, overlap resolution, markdown stripping, phrase matching, and empty-input cases.