### PR TITLE
feat: full agent audit logs + plan-as-issue-comment persistence

### DIFF
--- a/.claude/skills/plan-exec/SKILL.md
+++ b/.claude/skills/plan-exec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-exec
-description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue that is unlabelled (fresh) or at state:needs-planning or state:needs-rework. Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
-version: 1.0.0
+description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue that is unlabelled (fresh) or at state:needs-planning or state:needs-rework. Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, post a `<!-- agent-plan v1 -->` comment summarizing intent, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
+version: 1.1.0
 ---
 
 # plan-exec
@@ -106,7 +106,33 @@ The issue should carry `type:*`, `priority:*`, and ideally `area:*`. Add what's 
 gh issue edit <N> --add-label "<comma,separated,labels>"
 ```
 
-### 6. Implement
+### 6. Post the plan
+
+Before writing any code, post a single issue comment that captures *what you are about to do*. This is the only artefact of plan-exec's intent that survives — Stage 2 reads it for context, Stage 3 deliberately ignores it (the reviewer judges against the issue body and the diff, not your stated intent).
+
+The comment **must** start with the marker line `<!-- agent-plan v1 -->`. The marker is what test-writer searches for and what review-pr filters out.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-plan v1 -->
+## Plan
+
+**Goal:** <one-sentence restatement of what the issue asks>
+
+**Approach:** <one paragraph: where the change lives, why this shape over alternatives>
+
+**Files to change:**
+- `<path>` — <what changes there>
+- ...
+
+**Out of scope:** <anything explicit you are NOT doing this cycle, if relevant>
+EOF
+)"
+```
+
+Keep it short — under ~25 lines. A plan that reads like a transcript is useless. On rework cycles post a *new* comment (do not edit prior ones); test-writer reads the latest, and the older plans stay as history.
+
+### 7. Implement
 
 Follow the `dev-flow` skill. Specifically:
 - Keep the diff focused on this issue's scope.
@@ -116,7 +142,7 @@ Follow the `dev-flow` skill. Specifically:
 
 **Do NOT write tests yourself.** Stage 2 (test-writer) writes the tests in a fresh session. You write the implementation only. The exception: if existing tests need updating because behaviour legitimately changed, update them as part of your commit.
 
-### 7. Smoke check
+### 8. Smoke check
 
 Before committing, prove the code at least compiles and existing tests still pass:
 
@@ -127,7 +153,7 @@ source .venv/bin/activate && python -m pytest -q
 
 If existing tests now fail, fix the code (not the tests) until the suite is green. New-code-path coverage is Stage 2's job, not yours.
 
-### 8. Commit
+### 9. Commit
 
 One focused commit. Subject ≤ 70 chars, imperative mood. Body explains the why. End the body with `Refs #<N>` (not `Closes #<N>` — Stage 2's PR carries the closer).
 
@@ -145,7 +171,7 @@ EOF
 
 Don't `git add -A` or `git add .` — name the files you changed to avoid pulling in stray local artefacts.
 
-### 9. Hand off
+### 10. Hand off
 
 ```bash
 gh issue edit <N> \

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-pr
-description: Stage 3 of the autonomous pipeline. FRESH session. Invoked headlessly by scripts/agent-review.sh against an issue at state:in-review. Reads the issue body + Q&A comments + full PR diff (incl tests). Re-runs pytest as the merge gate. Outcomes are exactly one of three branches — APPROVE (gh pr merge --squash --delete-branch; the issue auto-closes via Closes #N), REJECT (gh pr review --request-changes with specific comments + flip issue to state:needs-rework), or BLOCK (flip to state:blocked + comment why; never merge). Block triggers are explicit in the safety checklist — secrets, CI tampering, schema risk, suspicious deps, service files, scope drift big enough to look like a different change.
-version: 1.0.0
+description: Stage 3 of the autonomous pipeline. FRESH session. Invoked headlessly by scripts/agent-review.sh against an issue at state:in-review. Reads the issue body + human Q&A comments + full PR diff (incl tests). Deliberately ignores `<!-- agent-plan v1 -->` comments — those are plan-exec's stated intent, and reviewing against intent biases the verdict toward "did the agent do what it said" instead of "does the diff solve the issue." Re-runs pytest as the merge gate. Outcomes are exactly one of three branches — APPROVE (gh pr merge --squash --delete-branch; the issue auto-closes via Closes #N), REJECT (gh pr review --request-changes with specific comments + flip issue to state:needs-rework), or BLOCK (flip to state:blocked + comment why; never merge). Block triggers are explicit in the safety checklist — secrets, CI tampering, schema risk, suspicious deps, service files, scope drift big enough to look like a different change.
+version: 1.1.0
 ---
 
 # review-pr
@@ -41,13 +41,16 @@ If multiple open PRs reference the issue, that's a bug — comment on the issue,
 
 ### 2. Read everything
 
+Read the issue body + human Q&A comments + PR title/body + full diff. **Filter out any comment whose body starts with `<!-- agent-plan`** — those are plan-exec's stated intent, not human Q&A. Reading them biases the review toward "did the agent do what it said it would" instead of "does the diff actually solve the issue."
+
 ```bash
-gh issue view <N> --json title,body,comments
+gh issue view <N> --json title,body,comments \
+  --jq '{title, body, comments: [.comments[] | select((.body | startswith("<!-- agent-plan")) | not)]}'
 gh pr view "$PR" --json title,body,headRefName,baseRefName,additions,deletions,changedFiles
 gh pr diff "$PR"
 ```
 
-Capture: the issue's intent (body + clarification Q&A), what the PR claims to do (title + body), and the full diff.
+Capture: the issue's intent (body + clarification Q&A only), what the PR claims to do (title + body), and the full diff.
 
 ### 3. Switch to the PR branch and re-run pytest
 
@@ -164,3 +167,4 @@ If two outcomes seem to apply (e.g. red pytest **and** secret in diff), choose *
 - Re-run pytest more than once trying to get green. Flake-hunting belongs to plan-exec / test-writer, not Stage 3.
 - Leave the issue at `state:in-review` after deciding. Always flip exactly once.
 - Merge with a different strategy (`--merge` / `--rebase`). The pipeline assumes squash so each issue maps to one main commit.
+- **Read `<!-- agent-plan` comments.** Those are plan-exec's stated intent. Reviewing against intent rather than the diff biases the verdict — the reviewer's job is to judge what the code does against what the issue asked for, not to grade the implementer's plan adherence. Filter them out at the `gh issue view` step (see step 2).

--- a/.claude/skills/test-writer/SKILL.md
+++ b/.claude/skills/test-writer/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: test-writer
-description: Stage 2 of the autonomous pipeline. FRESH session — no plan-exec rationale. Invoked headlessly by scripts/agent-test-write.sh on a state:tests-pending issue. Locates the implementation branch left by plan-exec, reads the branch diff (excluding existing test changes), writes new tests for the new code paths matching project style, runs pytest. On green commits the tests, pushes, opens or updates the PR with `Closes #<N>`, flips state:tests-pending → state:in-review. On red after self-checking that the test reflects the diff's actual behaviour, comments on the issue with the failure, flips state:tests-pending → state:needs-rework, and leaves the broken state local-only. Never modifies code outside tests/.
-version: 1.0.0
+description: Stage 2 of the autonomous pipeline. FRESH session — no plan-exec rationale beyond the issue's `<!-- agent-plan v1 -->` comment. Invoked headlessly by scripts/agent-test-write.sh on a state:tests-pending issue. Locates the implementation branch left by plan-exec, reads the latest agent-plan comment for intent, reads the branch diff (excluding existing test changes), writes new tests for the new code paths matching project style, runs pytest. On green commits the tests, pushes, opens or updates the PR with `Closes #<N>`, flips state:tests-pending → state:in-review. On red after self-checking that the test reflects the diff's actual behaviour, comments on the issue with the failure, flips state:tests-pending → state:needs-rework, and leaves the broken state local-only. Never modifies code outside tests/.
+version: 1.1.0
 ---
 
 # test-writer
 
-Stage 2 of the issue → merged pipeline (`workflow.md`). FRESH session — you do not see plan-exec's reasoning, only the code it produced. The point: test what the code does, not what the issue asked for.
+Stage 2 of the issue → merged pipeline (`workflow.md`). FRESH session — you do not see plan-exec's reasoning live, only the code it produced and a brief `<!-- agent-plan v1 -->` comment it left on the issue. The point: test what the code does, not what the issue asked for. The plan comment is context for *why*; the diff is still the source of truth for *what*.
 
 ## Hard boundaries
 
@@ -54,7 +54,18 @@ git fetch origin "$BRANCH" 2>/dev/null || true
 git checkout "$BRANCH"
 ```
 
-### 2. Read the diff
+### 2. Read plan-exec's intent
+
+plan-exec leaves a plan comment on the issue tagged `<!-- agent-plan v1 -->`. Fetch the **latest** one (rework cycles append a fresh plan each pass) and read it for context — to understand which behaviours are being introduced and why this shape was chosen. The diff is still the source of truth for what to test; the plan tells you the goal.
+
+```bash
+gh issue view <N> --json comments -q \
+  '[.comments[] | select(.body | startswith("<!-- agent-plan"))] | last | .body // ""'
+```
+
+If no plan comment exists (older issues, or a plan-exec run that pre-dates this convention), proceed without it — the diff alone is enough. Do not bounce-back over a missing plan comment.
+
+### 3. Read the diff
 
 ```bash
 git diff main...HEAD -- ':!tests/'
@@ -62,9 +73,9 @@ git diff main...HEAD -- ':!tests/'
 
 Excluding `tests/` is deliberate. You write the tests; you do not let plan-exec's test edits anchor your judgment.
 
-### 3. Decide: do new code paths exist?
+### 4. Decide: do new code paths exist?
 
-If the diff is purely cosmetic (docstring, comment, whitespace), no new tests are needed — skip to step 6 and open the PR with no test commit.
+If the diff is purely cosmetic (docstring, comment, whitespace), no new tests are needed — skip to step 7 and open the PR with no test commit.
 
 If the diff adds new functions, branches, error paths, or behaviour, you owe tests for them. Match the existing test style — open `tests/` and read a few files first:
 
@@ -74,7 +85,7 @@ If the diff adds new functions, branches, error paths, or behaviour, you owe tes
 - One concept per test function. Test names describe the behaviour, not the function name.
 - `from __future__ import annotations` at the top of each test module.
 
-### 4. Write the tests
+### 5. Write the tests
 
 Edit / create files in `tests/` only. Cover, in this order of priority:
 
@@ -84,13 +95,13 @@ Edit / create files in `tests/` only. Cover, in this order of priority:
 
 Don't over-write. A small focused test that would fail without the change is better than a sprawling one that exercises the whole module.
 
-### 5. Run pytest
+### 6. Run pytest
 
 ```bash
 source .venv/bin/activate && python -m pytest -q
 ```
 
-#### Green → step 6.
+#### Green → step 7.
 
 #### Red → self-check, then either fix-test or bounce-back.
 
@@ -123,7 +134,7 @@ Then **stop**. Do not push, do not commit failing tests. Your draft tests stay l
 
 The bar for bouncing back: *would another reasonable agent reading only the diff write the same test and see it fail?*
 
-### 6. Commit, push, open or update the PR
+### 7. Commit, push, open or update the PR
 
 If you wrote new tests:
 
@@ -164,7 +175,7 @@ EOF
 
 If the diff was purely cosmetic and you wrote no new tests, still push and open/update the PR. Note it in the test plan: `- [n/a] No code paths changed; existing suite still green`.
 
-### 7. Flip the label
+### 8. Flip the label
 
 ```bash
 gh issue edit <N> \
@@ -172,7 +183,7 @@ gh issue edit <N> \
   --add-label "state:in-review"
 ```
 
-### 8. Exit
+### 9. Exit
 
 Print one line: `done: pushed <BRANCH> at <short-sha>, PR #<P> ready for review`.
 

--- a/scripts/agent-plan-exec.sh
+++ b/scripts/agent-plan-exec.sh
@@ -72,15 +72,22 @@ prompt="Run the plan-exec skill for issue #${ISSUE}. Current state: ${state_labe
 echo "[plan-exec] dispatching for issue #${ISSUE} (state=${state_label:-unlabelled})"
 echo "[plan-exec] log: ${log}"
 
+# --output-format stream-json --verbose: emit a JSONL audit trail of every
+# tool call, message, and result event. Raw JSONL goes to "$log"; the final
+# assistant message is extracted via jq for the human watching the terminal.
+# Pretty-print a saved log with: jq . "$log"
 # --no-session-persistence: each run is a fresh, unrecoverable session.
 # --permission-mode bypassPermissions: required for headless — no human to approve prompts.
 # IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
 # under root by default; the env var opts in for sandboxed VPS / container hosts.
 IS_SANDBOX=1 claude -p \
+    --output-format stream-json --verbose \
     --model claude-opus-4-7 \
     --no-session-persistence \
     --permission-mode bypassPermissions \
-    "$prompt" 2>&1 | tee "$log"
+    "$prompt" 2>&1 \
+    | tee "$log" \
+    | jq -rR 'fromjson? | select(.type=="result") | .result // empty'
 
 # --- post-run summary ---------------------------------------------------
 

--- a/scripts/agent-review.sh
+++ b/scripts/agent-review.sh
@@ -75,15 +75,22 @@ prompt="Run the review-pr skill for issue #${ISSUE}. The PR is #${pr_number}. De
 echo "[review] dispatching for issue #${ISSUE} (PR #${pr_number})"
 echo "[review] log: ${log}"
 
+# --output-format stream-json --verbose: emit a JSONL audit trail of every
+# tool call, message, and result event. Raw JSONL goes to "$log"; the final
+# assistant message is extracted via jq for the human watching the terminal.
+# Pretty-print a saved log with: jq . "$log"
 # --no-session-persistence: every Stage 3 run is a fresh, isolated session.
 # --permission-mode bypassPermissions: required for headless — no human to approve prompts.
 # IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
 # under root by default; the env var opts in for sandboxed VPS / container hosts.
 IS_SANDBOX=1 claude -p \
+    --output-format stream-json --verbose \
     --model claude-opus-4-7 \
     --no-session-persistence \
     --permission-mode bypassPermissions \
-    "$prompt" 2>&1 | tee "$log"
+    "$prompt" 2>&1 \
+    | tee "$log" \
+    | jq -rR 'fromjson? | select(.type=="result") | .result // empty'
 
 # --- post-run summary ---------------------------------------------------
 

--- a/scripts/agent-test-write.sh
+++ b/scripts/agent-test-write.sh
@@ -66,15 +66,22 @@ prompt="Run the test-writer skill for issue #${ISSUE}. The implementation branch
 echo "[test-write] dispatching for issue #${ISSUE}"
 echo "[test-write] log: ${log}"
 
+# --output-format stream-json --verbose: emit a JSONL audit trail of every
+# tool call, message, and result event. Raw JSONL goes to "$log"; the final
+# assistant message is extracted via jq for the human watching the terminal.
+# Pretty-print a saved log with: jq . "$log"
 # --no-session-persistence: every Stage 2 run is a fresh, blind-of-Stage-1 session.
 # --permission-mode bypassPermissions: required for headless — no human to approve prompts.
 # IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
 # under root by default; the env var opts in for sandboxed VPS / container hosts.
 IS_SANDBOX=1 claude -p \
+    --output-format stream-json --verbose \
     --model claude-opus-4-7 \
     --no-session-persistence \
     --permission-mode bypassPermissions \
-    "$prompt" 2>&1 | tee "$log"
+    "$prompt" 2>&1 \
+    | tee "$log" \
+    | jq -rR 'fromjson? | select(.type=="result") | .result // empty'
 
 # --- post-run summary ---------------------------------------------------
 

--- a/tests/test_agent_plan_exec.py
+++ b/tests/test_agent_plan_exec.py
@@ -90,3 +90,20 @@ def test_script_accepts_unlabelled_fresh_issues() -> None:
     text = SCRIPT.read_text()
     # The case statement must include "" as a valid starting state.
     assert '""|state:needs-planning|state:needs-rework' in text
+
+
+def test_script_emits_stream_json_audit_log() -> None:
+    """Stage 1 runs must produce a JSONL audit trail of every tool call,
+    not just the final assistant message — that is the whole point of
+    logs/agents/. The dispatch must pass --output-format stream-json --verbose
+    and tee the raw stream to the log file."""
+    text = SCRIPT.read_text()
+    assert "--output-format stream-json --verbose" in text
+    assert 'tee "$log"' in text
+
+
+def test_script_extracts_final_result_for_terminal() -> None:
+    """JSONL is for the log; the human watching the terminal still wants the
+    final summary line. jq extracts the type==result event."""
+    text = SCRIPT.read_text()
+    assert 'select(.type=="result")' in text

--- a/tests/test_agent_review.py
+++ b/tests/test_agent_review.py
@@ -94,3 +94,17 @@ def test_script_passes_pr_number_to_agent() -> None:
     """The agent prompt must reference both the issue and PR numbers."""
     text = SCRIPT.read_text()
     assert "PR is #" in text or "PR #${pr_number}" in text or "PR is #${pr_number}" in text
+
+
+def test_script_emits_stream_json_audit_log() -> None:
+    """Stage 3 runs must produce a JSONL audit trail of every tool call,
+    not just the final assistant message."""
+    text = SCRIPT.read_text()
+    assert "--output-format stream-json --verbose" in text
+    assert 'tee "$log"' in text
+
+
+def test_script_extracts_final_result_for_terminal() -> None:
+    """jq extracts the type==result event so the human still sees the summary."""
+    text = SCRIPT.read_text()
+    assert 'select(.type=="result")' in text

--- a/tests/test_agent_test_write.py
+++ b/tests/test_agent_test_write.py
@@ -81,3 +81,17 @@ def test_script_validates_tests_pending_state() -> None:
     """Stage 2 only runs on state:tests-pending; mismatched state must fail."""
     text = SCRIPT.read_text()
     assert "state:tests-pending" in text
+
+
+def test_script_emits_stream_json_audit_log() -> None:
+    """Stage 2 runs must produce a JSONL audit trail of every tool call,
+    not just the final assistant message."""
+    text = SCRIPT.read_text()
+    assert "--output-format stream-json --verbose" in text
+    assert 'tee "$log"' in text
+
+
+def test_script_extracts_final_result_for_terminal() -> None:
+    """jq extracts the type==result event so the human still sees the summary."""
+    text = SCRIPT.read_text()
+    assert 'select(.type=="result")' in text

--- a/workflow.md
+++ b/workflow.md
@@ -68,6 +68,14 @@ A single-issue serial pipeline where three Claude agents — plan-exec, test-wri
 
 Three human gates only: **filing the issue**, **answering clarifications**, **un-blocking parked issues**.
 
+### Plan comments (`<!-- agent-plan v1 -->`)
+
+Before implementing, plan-exec posts a single issue comment whose body starts with the marker line `<!-- agent-plan v1 -->`. The comment captures *what plan-exec intended to do this cycle* — goal, approach, files to touch, anything explicitly out of scope. Each cycle posts a fresh comment (rework cycles do not edit older ones), so the issue accumulates a chronological history of intent.
+
+Stage 2 (test-writer) reads the latest such comment for context — to understand what behaviours are being introduced and why this shape — but still treats the diff as the source of truth for what to test.
+
+Stage 3 (reviewer) **deliberately filters these comments out**. Reviewing against the implementer's stated intent biases the verdict toward "did the agent do what it said it would" instead of "does the diff actually solve the issue." The reviewer judges only against the issue body, the human Q&A comments, and the diff itself.
+
 ## State labels
 
 The full label set lives in `scripts/setup-labels.sh` (idempotent — safe to re-run).


### PR DESCRIPTION
## Summary

Two coupled improvements to the autonomous-pipeline workflow that fell out of dogfooding the first end-to-end run on the VPS:

1. **Audit logs.** All three dispatch scripts (`agent-plan-exec.sh`, `agent-test-write.sh`, `agent-review.sh`) now invoke claude with `--output-format stream-json --verbose` and tee the raw JSONL into `logs/agents/*.log`. The previous default mode only emitted the final assistant message — `cat plan-exec-35-*.log` returned a one-liner with no record of what the agent actually did. The human-readable summary line is preserved on stdout via a small `jq` filter.

   Read a stored log with `jq . logs/agents/<file>.log`.

2. **Plan persistence.** `plan-exec` now posts a single issue comment marked with `<!-- agent-plan v1 -->` before implementing, capturing goal / approach / files-to-touch. `test-writer` reads the latest such comment for context (the diff is still source-of-truth for what to test). `review-pr` is told explicitly to filter these out at the `gh issue view` step and the rule is repeated in the don't-do list — keeping the reviewer's verdict driven by the diff and the issue body rather than by the implementer's stated intent.

   Marker convention is documented in `workflow.md` so future skill revisions don't drop the filter by accident.

## Files

- `scripts/agent-{plan-exec,test-write,review}.sh` — stream-json + jq extraction
- `.claude/skills/plan-exec/SKILL.md` — new step 6 (post plan), renumbered the rest
- `.claude/skills/test-writer/SKILL.md` — new step 2 (read latest plan), renumbered the rest
- `.claude/skills/review-pr/SKILL.md` — filter in step 2 + explicit don't-read rule
- `workflow.md` — convention documented under "Plan comments"
- `tests/test_agent_*.py` — assert new flags + `select(.type==\"result\")` extraction

## Test plan

- [x] \`pytest -q\` is green (225 passed)
- [x] \`bash -n\` clean on all three scripts
- [ ] Run \`./scripts/agent-plan-exec.sh\` against a fresh issue on the VPS and verify (a) \`logs/agents/plan-exec-*.log\` is many-line JSONL not a one-liner, (b) terminal still shows the \`done: ...\` summary, (c) the issue receives a \`<!-- agent-plan v1 -->\` comment.
- [ ] Then run \`./scripts/agent-test-write.sh\` and confirm test-writer reads the plan comment.
- [ ] Then run \`./scripts/agent-review.sh\` and confirm reviewer's \`gh issue view\` invocation filters the agent-plan comment out.