### PR TITLE
Nest agent logs under logs/agents/<issue>/

### DIFF
--- a/scripts/agent-plan-exec.sh
+++ b/scripts/agent-plan-exec.sh
@@ -3,7 +3,7 @@
 #
 # Spawns a headless Claude session with the plan-exec skill loaded against
 # a specific GitHub issue. Validates the issue exists and is in an expected
-# state, then dispatches. Logs to logs/agents/plan-exec-<N>-<ts>.log.
+# state, then dispatches. Logs to logs/agents/<N>/plan-exec-<ts>.log.
 #
 # Usage: scripts/agent-plan-exec.sh <issue-number>
 #
@@ -60,10 +60,10 @@ esac
 # --- log paths ----------------------------------------------------------
 
 repo_root="$(git rev-parse --show-toplevel)"
-log_dir="${repo_root}/logs/agents"
+log_dir="${repo_root}/logs/agents/${ISSUE}"
 mkdir -p "$log_dir"
 ts=$(date +%Y%m%d-%H%M%S)
-log="${log_dir}/plan-exec-${ISSUE}-${ts}.log"
+log="${log_dir}/plan-exec-${ts}.log"
 
 # --- dispatch -----------------------------------------------------------
 

--- a/scripts/agent-review.sh
+++ b/scripts/agent-review.sh
@@ -3,7 +3,7 @@
 #
 # Spawns a headless Claude session with the review-pr skill loaded
 # against an issue at state:in-review. Resolves the PR from the issue,
-# validates state, dispatches. Logs to logs/agents/review-<N>-<ts>.log.
+# validates state, dispatches. Logs to logs/agents/<N>/review-<ts>.log.
 #
 # Usage: scripts/agent-review.sh <issue-number>
 #
@@ -63,10 +63,10 @@ fi
 # --- log paths ----------------------------------------------------------
 
 repo_root="$(git rev-parse --show-toplevel)"
-log_dir="${repo_root}/logs/agents"
+log_dir="${repo_root}/logs/agents/${ISSUE}"
 mkdir -p "$log_dir"
 ts=$(date +%Y%m%d-%H%M%S)
-log="${log_dir}/review-${ISSUE}-${ts}.log"
+log="${log_dir}/review-${ts}.log"
 
 # --- dispatch -----------------------------------------------------------
 

--- a/scripts/agent-test-write.sh
+++ b/scripts/agent-test-write.sh
@@ -3,7 +3,7 @@
 #
 # Spawns a headless Claude session with the test-writer skill loaded
 # against an issue at state:tests-pending. Validates state, dispatches,
-# logs to logs/agents/test-write-<N>-<ts>.log.
+# logs to logs/agents/<N>/test-write-<ts>.log.
 #
 # Usage: scripts/agent-test-write.sh <issue-number>
 #
@@ -54,10 +54,10 @@ fi
 # --- log paths ----------------------------------------------------------
 
 repo_root="$(git rev-parse --show-toplevel)"
-log_dir="${repo_root}/logs/agents"
+log_dir="${repo_root}/logs/agents/${ISSUE}"
 mkdir -p "$log_dir"
 ts=$(date +%Y%m%d-%H%M%S)
-log="${log_dir}/test-write-${ISSUE}-${ts}.log"
+log="${log_dir}/test-write-${ts}.log"
 
 # --- dispatch -----------------------------------------------------------
 

--- a/workflow.md
+++ b/workflow.md
@@ -192,7 +192,7 @@ Each agent script:
 1. Validates the issue/PR is in the expected state.
 2. Builds a prompt from the issue body + comments (or PR diff).
 3. Spawns `claude -p --model claude-opus-4-7 "<prompt>"` with the relevant skill name in the prompt.
-4. Logs stdout/stderr to `logs/agents/<stage>-<issue#>-<timestamp>.log`.
+4. Logs stdout/stderr to `logs/agents/<issue#>/<stage>-<timestamp>.log`.
 5. Exits non-zero if the agent didn't flip the label as expected — the orchestrator logs and moves on.
 
 ## Deployment (VPS)


### PR DESCRIPTION
## Summary
- Each Stage script (plan-exec / test-write / review) now writes to `logs/agents/<issue#>/<stage>-<ts>.log` instead of a flat `logs/agents/<stage>-<issue#>-<ts>.log`.
- All runs for one issue cluster in a single folder, so it's easier to scan a single issue's audit trail.
- `workflow.md` updated to match.

## Test plan
- [x] `bash -n` on all three scripts
- [x] `pytest tests/test_agent_plan_exec.py tests/test_agent_test_write.py tests/test_agent_review.py` (41 passed)
- [ ] First headless run lands a log under `logs/agents/<N>/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)