### PR TITLE
feat: epic decomposition skill and dispatcher

### DIFF
--- a/.claude/skills/epic-decompose/SKILL.md
+++ b/.claude/skills/epic-decompose/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: epic-decompose
+description: Pre-Stage-1 skill for issues labelled `type:epic`. Runs headless from `scripts/agent-epic-decompose.sh` on a single epic and decomposes it into a set of child issues that the regular plan-exec → test-writer → reviewer pipeline can ship. Multi-round Socratic Q&A with the user across many invocations (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files the children with `Refs #<parent>`, and parks the parent at `state:tracking`. Does NOT cut branches, write code, or open PRs.
+version: 1.0.0
+---
+
+# epic-decompose
+
+Decomposition stage for big features. Splits a `type:epic` parent issue into smaller child issues that the existing pipeline can ship one at a time. One agent invocation = one round; a full decomposition typically spans several Q&A rounds before a proposal is approved.
+
+## Hard boundaries
+
+You MAY:
+- `gh issue view`, `gh issue list`, `gh issue create` (file children).
+- `gh issue comment`, `gh issue edit` (labels) on the parent.
+- Read code to ground your understanding of where the change would land.
+
+You MUST NOT:
+- Edit code, create branches, commit, push, or open PRs. Decomposition is research and planning only — implementation belongs to plan-exec on each *child* issue.
+- Decompose anything that is **not** labelled `type:epic`. Bounce back to plan-exec if you were dispatched on the wrong issue.
+- File child issues until the user has explicitly approved your latest proposal with the `/decompose-ok` magic phrase.
+
+## Inputs and exit conditions
+
+Dispatched at one of two states:
+- `state:needs-planning` — the entry/resume state. Either the first round, or the user resumed after a clarification answer or feedback on a proposal.
+- `state:awaiting-decompose-approval` — defensive; the runner script accepts this too. In practice the user flips back to `needs-planning` when they want the next dispatch to act.
+
+Exits the run by flipping to one of:
+- `state:clarification-needed` — you posted a question, awaiting answer.
+- `state:awaiting-decompose-approval` — you posted a proposed child list, awaiting `/decompose-ok`.
+- `state:tracking` — children filed, parent now waits for them to merge.
+- `state:blocked` — round cap exhausted or unresolvable error (rare).
+
+## The decision tree (do this every dispatch)
+
+Read the issue body and **all** comments. Then walk this tree top-down — first match wins:
+
+1. **Approval detected.** A user comment that contains `/decompose-ok` exists and is dated *after* your most recent `<!-- agent-decompose v1 -->` proposal comment.
+   → File the children (see §4), flip to `state:tracking`, exit.
+
+2. **Round cap hit.** You've already posted ≥ 8 `<!-- agent-decompose-q v1 -->` question comments.
+   → Force a proposal anyway, but tag it `**Confidence: low — round cap reached.**` (see §3 with the tag added), flip to `state:awaiting-decompose-approval`, exit.
+
+3. **Ready to propose.** You have enough information to draft a credible child-issue list — every must-answer question from §5 has either been answered or is genuinely deferrable.
+   → Post the proposal (see §3), flip to `state:awaiting-decompose-approval`, exit.
+
+4. **Need more information.** Default branch.
+   → Post one focused question (see §2), flip to `state:clarification-needed`, exit.
+
+**Bias toward more questions, not fewer.** The cost of a wrong cut-line is multiple ill-shaped child issues. The cost of one extra Q&A round is one tick. Err on the side of asking.
+
+## 1. First step on every dispatch — flip to in-progress
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:needs-planning,state:awaiting-decompose-approval" \
+  --add-label "state:in-progress"
+```
+
+`gh` ignores `--remove-label` for labels that aren't present, so the same command works from either entry state.
+
+## 2. Question round
+
+One question per round. The single most load-bearing unknown — what would change the *shape* of the decomposition if answered the other way.
+
+Bad: "What are your thoughts on the architecture?"
+Good: "Should the part-of-speech classifier run at `/add` time (one-shot, stored on the row) or lazily on first push (cached)? The two paths split the work very differently."
+
+Marker `<!-- agent-decompose-q v1 -->` is mandatory — the round counter and future dispatches read it.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-decompose-q v1 -->
+**Decomposition question (round <K> of up to 8)**
+
+<the precise question>
+
+Context: <one sentence — what you've already concluded, what depends on this>.
+
+When you answer, flip the label back to `state:needs-planning` to re-enter the loop.
+EOF
+)"
+```
+
+Then flip the state and exit:
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:clarification-needed"
+```
+
+Print `paused at round <K>: clarification posted` and stop. Do not propose in the same round you ask.
+
+## 3. Propose round
+
+A proposal is a complete, dependency-ordered child list. Every child should be small enough that plan-exec can ship it as one focused PR (~300 LOC, one area), with crisp acceptance criteria.
+
+Marker `<!-- agent-decompose v1 -->` is mandatory.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-decompose v1 -->
+## Proposed decomposition for #<N>
+
+**Confidence:** high | medium | low — round cap reached (use this tag if you hit §H2).
+
+**One-line shape:** <how the children fit together>.
+
+### Child 1 — <imperative title>
+- **Labels:** `type:feat`, `priority:high`, `area:vocab`
+- **Goal:** <one sentence>
+- **Acceptance criteria:**
+  - AC1: <given X, when Y, then Z>
+  - AC2: <invariant>
+- **Depends on:** none (or "child #2 must merge first")
+- **Out of scope:** <what is explicitly NOT in this child>
+
+### Child 2 — ...
+
+---
+
+**Reply `/decompose-ok` to approve.** Then flip `state:awaiting-decompose-approval` → `state:needs-planning` and the next dispatch will file these as child issues. To request changes, comment your feedback and flip back to `state:needs-planning` — I'll revise.
+EOF
+)"
+```
+
+Then:
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:awaiting-decompose-approval"
+```
+
+Print `proposal posted: <N> children, awaiting approval` and exit.
+
+**Sizing rule of thumb.** Aim for 3–8 children. Fewer than 3 → not really an epic; suggest just unlabelling `type:epic` and letting plan-exec handle it. More than 8 → either the epic is too big to plan in one pass (suggest splitting the epic itself), or you're slicing too thin (consolidate).
+
+## 4. File-children round (after `/decompose-ok`)
+
+Triggered when §A1 of the decision tree matches. For each child in the most recent proposal, in the order you listed them:
+
+```bash
+gh issue create \
+  --title "<imperative title>" \
+  --label "type:feat,priority:medium,area:vocab,state:needs-planning" \
+  --body "$(cat <<EOF
+<one-paragraph problem statement, lifted from the proposal>
+
+## Acceptance criteria
+- AC1: ...
+- AC2: ...
+
+## Out of scope
+- ...
+
+Part of epic #<N>.
+Refs #<N>
+EOF
+)"
+```
+
+Capture each new issue number from the URL `gh issue create` prints. Then post one closing comment on the parent that lists the child links and flip to `state:tracking`:
+
+```bash
+gh issue comment <N> --body "$(cat <<EOF
+<!-- agent-decompose-filed v1 -->
+**Decomposition filed.** Children:
+
+- #<C1> — <title>
+- #<C2> — <title>
+- ...
+
+Parent will auto-close once all children are closed (orchestrator coordinator).
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:tracking"
+```
+
+Print `filed <K> children for epic #<N>: <numbers>` and exit.
+
+> **Coordinator caveat:** the auto-close-on-children-done coordinator lives in the orchestrator (separate increment). Until that ships, the parent stays at `state:tracking` and the user closes it manually after all children merge. Mention this in the closing comment if the orchestrator is not yet deployed.
+
+## 5. What "must-answer" questions look like for an epic
+
+A non-exhaustive checklist of the kinds of unknowns to clear before proposing. Walk through these mentally on every Q-round and pick the most load-bearing unanswered one:
+
+- **Scope edges.** What is explicitly *not* in scope for this epic? (Without this you'll over-decompose.)
+- **Storage shape.** New tables / columns? Migration concerns?
+- **User-facing surface.** New slash commands? Inline UI? `/start` flow changes?
+- **Dependency order.** What must merge before what? Are any children blockers vs leaves?
+- **Integration points.** Does this touch the LLM call site, the scheduler, the translator, the FSRS state machine?
+- **Test seams.** Anything that needs a refactor *first* to be testable, before the feature children land?
+- **External services / config.** New env vars? New API keys? Quotas?
+- **Naming.** Names of new commands, modules, labels — pick *or* ask.
+
+## After-the-loop notes
+
+- **You don't run plan-exec on the parent.** Once children are filed, the parent's job is over. plan-exec will be dispatched separately on each child by the normal pipeline.
+- **Don't overlap with `clarify-issue`.** That skill is for *implementation* clarifications during plan-exec; epic-decompose has its own Q&A flow with its own marker so the two histories don't tangle.
+- **Don't cycle past 8 questions** without forcing a proposal. The round cap exists so an over-cautious agent can't deadlock the epic.
+- **One commit-style discipline.** Every child issue's acceptance criteria should map cleanly to tests in test-writer's spec format (numbered, behavioural, not implementation). Test-writer reads only the AC block — sloppy ACs here become sloppy tests downstream.

--- a/scripts/agent-epic-decompose.sh
+++ b/scripts/agent-epic-decompose.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# agent-epic-decompose.sh — pre-Stage-1 runner for `type:epic` issues.
+#
+# Spawns a headless Claude session with the epic-decompose skill loaded
+# against an epic that needs decomposition into child issues. One run =
+# one round (Q&A, proposal, or file-children — see the skill's decision
+# tree). Multi-round flows resume by re-running this script after the
+# user flips the state label back to `state:needs-planning`.
+#
+# Usage: scripts/agent-epic-decompose.sh <issue-number>
+#
+# Exit codes:
+#   0  — claude session ran (does not imply success; check logs and labels)
+#   1  — bad arguments
+#   2  — issue not found, closed, missing type:epic, or in unexpected state
+#   3  — required CLI missing (claude / gh / jq)
+
+set -euo pipefail
+
+# --- argument parsing ---------------------------------------------------
+
+ISSUE="${1:-}"
+if [[ -z "$ISSUE" || ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+    echo "usage: $0 <issue-number>" >&2
+    exit 1
+fi
+
+# --- dependency checks --------------------------------------------------
+
+for cmd in claude gh jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "agent-epic-decompose: '$cmd' is required but not in PATH" >&2
+        exit 3
+    fi
+done
+
+# --- state validation ---------------------------------------------------
+
+if ! issue_json=$(gh issue view "$ISSUE" --json state,labels 2>&1); then
+    echo "agent-epic-decompose: cannot fetch issue #$ISSUE: $issue_json" >&2
+    exit 2
+fi
+
+issue_state=$(echo "$issue_json" | jq -r '.state')
+if [[ "$issue_state" != "OPEN" ]]; then
+    echo "agent-epic-decompose: issue #$ISSUE is $issue_state, expected OPEN" >&2
+    exit 2
+fi
+
+# Must carry type:epic — refuse otherwise so this script can't be misused
+# on regular issues (which belong to plan-exec).
+has_epic=$(echo "$issue_json" | jq -r '[.labels[].name] | any(. == "type:epic")')
+if [[ "$has_epic" != "true" ]]; then
+    echo "agent-epic-decompose: issue #$ISSUE is not labelled 'type:epic'; use agent-plan-exec.sh instead" >&2
+    exit 2
+fi
+
+state_label=$(echo "$issue_json" | jq -r '[.labels[].name] | map(select(startswith("state:"))) | .[0] // ""')
+case "$state_label" in
+    ""|state:needs-planning|state:awaiting-decompose-approval)
+        # Empty (fresh) → treat as needs-planning. awaiting-decompose-approval
+        # is the resume entry point after a user provides feedback or approval.
+        ;;
+    *)
+        echo "agent-epic-decompose: issue #$ISSUE is at '$state_label', expected unset, state:needs-planning, or state:awaiting-decompose-approval" >&2
+        exit 2
+        ;;
+esac
+
+# --- log paths ----------------------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+log_dir="${repo_root}/logs/agents/${ISSUE}"
+mkdir -p "$log_dir"
+ts=$(date +%Y%m%d-%H%M%S)
+log="${log_dir}/epic-decompose-${ts}.log"
+
+# --- dispatch -----------------------------------------------------------
+
+prompt="Run the epic-decompose skill for epic issue #${ISSUE}. Current state: ${state_label:-unlabelled (treat as state:needs-planning)}. Walk the decision tree on every dispatch — ask the next question, post a proposal, or (if /decompose-ok was given) file the children. One round per invocation."
+
+echo "[epic-decompose] dispatching for issue #${ISSUE} (state=${state_label:-unlabelled})"
+echo "[epic-decompose] log: ${log}"
+
+# --output-format stream-json --verbose: emit a JSONL audit trail of every
+# tool call, message, and result event. Raw JSONL goes to "$log"; the final
+# assistant message is extracted via jq for the human watching the terminal.
+# Pretty-print a saved log with: jq . "$log"
+# --no-session-persistence: each dispatch is a fresh round.
+# --permission-mode bypassPermissions: required for headless — no human to approve prompts.
+# IS_SANDBOX=1: claude refuses --dangerously-skip-permissions / bypassPermissions
+# under root by default; the env var opts in for sandboxed VPS / container hosts.
+IS_SANDBOX=1 claude -p \
+    --output-format stream-json --verbose \
+    --model claude-opus-4-7 \
+    --no-session-persistence \
+    --permission-mode bypassPermissions \
+    "$prompt" 2>&1 \
+    | tee "$log" \
+    | jq -rR 'fromjson? | select(.type=="result") | .result // empty'
+
+# --- post-run summary ---------------------------------------------------
+
+echo
+echo "[epic-decompose] final issue labels:"
+gh issue view "$ISSUE" --json labels -q '.labels[].name' | grep -E '^(state:|type:)' || echo "  (no state/type labels)"

--- a/scripts/agent-plan-exec.sh
+++ b/scripts/agent-plan-exec.sh
@@ -57,6 +57,15 @@ case "$state_label" in
         ;;
 esac
 
+# type:epic guard — these belong to agent-epic-decompose.sh, not plan-exec.
+# Plan-exec on an epic would try to ship the whole feature as one PR, which
+# is exactly what `type:epic` exists to prevent.
+has_epic=$(echo "$issue_json" | jq -r '[.labels[].name] | any(. == "type:epic")')
+if [[ "$has_epic" == "true" ]]; then
+    echo "agent-plan-exec: issue #$ISSUE is labelled 'type:epic'; dispatch scripts/agent-epic-decompose.sh instead" >&2
+    exit 2
+fi
+
 # --- log paths ----------------------------------------------------------
 
 repo_root="$(git rev-parse --show-toplevel)"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -20,19 +20,23 @@ create() {
 
 # State (blue) — workflow position; one-of, flips as the issue moves.
 # See workflow.md (State labels) for the full state machine.
-create "state:needs-planning"       "1d76db" "Untouched. Stage 1 (plan-exec) will pick this up"
-create "state:in-progress"          "1d76db" "Plan-exec is working on this issue"
-create "state:clarification-needed" "1d76db" "Agent posted a question; awaiting user input"
-create "state:tests-pending"        "1d76db" "Branch + commit ready; awaiting test-writer"
-create "state:in-review"            "1d76db" "PR open; reviewer is evaluating"
-create "state:needs-rework"         "1d76db" "Test or review failed; back to Stage 1"
-create "state:blocked"              "1d76db" "Stopped — needs human attention (cycle-limit, sensitive content, etc.)"
+create "state:needs-planning"               "1d76db" "Untouched. Stage 1 (plan-exec) will pick this up"
+create "state:in-progress"                  "1d76db" "Plan-exec is working on this issue"
+create "state:clarification-needed"         "1d76db" "Agent posted a question; awaiting user input"
+create "state:tests-pending"                "1d76db" "Branch + commit ready; awaiting test-writer"
+create "state:in-review"                    "1d76db" "PR open; reviewer is evaluating"
+create "state:needs-rework"                 "1d76db" "Test or review failed; back to Stage 1"
+create "state:awaiting-decompose-approval"  "1d76db" "Epic-decompose posted a proposal; awaiting /decompose-ok"
+create "state:tracking"                     "1d76db" "Epic — children filed; waiting for them to all close"
+create "state:blocked"                      "1d76db" "Stopped — needs human attention (cycle-limit, sensitive content, etc.)"
 
-# Type (green) — maps 1:1 to dev-flow branch prefixes.
+# Type (green) — maps 1:1 to dev-flow branch prefixes (epic is the exception:
+# it has no branch — agent-epic-decompose.sh splits it into typed children).
 create "type:feat"     "0e8a16" "New behaviour"
 create "type:fix"      "0e8a16" "Bug fix"
 create "type:chore"    "0e8a16" "Tooling, deps, docs"
 create "type:refactor" "0e8a16" "No behaviour change"
+create "type:epic"     "0e8a16" "Big feature — agent-epic-decompose.sh splits it into typed children"
 
 # Priority (red→amber→light) — user assigns; default medium.
 create "priority:high"   "d73a4a" "Urgent / blocking"

--- a/workflow.md
+++ b/workflow.md
@@ -72,6 +72,41 @@ A single-issue serial pipeline where three Claude agents — plan-exec, test-wri
 
 Three human gates only: **filing the issue**, **answering clarifications**, **un-blocking parked issues**.
 
+## Epic decomposition (pre-Stage-1)
+
+A fourth route for issues too big for one PR. Filed with `type:epic`, they bypass plan-exec and go to a dedicated decomposition skill that splits them into normal child issues which then enter the main pipeline one at a time.
+
+```
+user files type:epic issue (state:needs-planning)
+     │
+     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ pre-Stage-1 — epic-decompose                                │
+│ Skill: epic-decompose                                       │
+│ Script: scripts/agent-epic-decompose.sh                     │
+│                                                             │
+│ One dispatch = one round. Decision tree per dispatch:       │
+│   • approval seen (/decompose-ok) → file children           │
+│   • round cap (≥ 8 Qs) → force proposal w/ low-confidence   │
+│   • have enough info → propose                              │
+│   • otherwise → ask the next focused question               │
+│                                                             │
+│ Q round → state:clarification-needed (user answers)         │
+│ Propose round → state:awaiting-decompose-approval           │
+│ File-children round → state:tracking                        │
+└─────────────────────────────────────────────────────────────┘
+     │
+     ▼ children filed with Refs #<parent>, type:feat|fix|chore|refactor
+     │ each child enters the main three-stage pipeline normally
+     │
+     ▼ all children closed → parent closes (orchestrator coordinator;
+                              manual close until that ships)
+```
+
+The parent at `state:tracking` is the "loop until done" pattern — it just waits for its children to drain through the regular pipeline. There is no integration / smoke pass on the parent in v1; cross-issue bugs that ship are caught by use and filed as fresh issues (consistent with the rest of the pipeline's auto-merge posture).
+
+The user gates are: filing the epic, answering Q-round clarifications, **approving the proposed decomposition with `/decompose-ok`**, and (for now) closing the parent once children merge. `agent-plan-exec.sh` refuses `type:epic` issues so a misfire can't land an epic in the wrong stage.
+
 ### Plan comments (`<!-- agent-plan v1 -->`)
 
 Before implementing, plan-exec posts a single issue comment whose body starts with the marker line `<!-- agent-plan v1 -->`. The comment has two halves:
@@ -93,19 +128,21 @@ The full label set lives in `scripts/setup-labels.sh` (idempotent — safe to re
 
 | Label | Set by | Means |
 |---|---|---|
-| `state:needs-planning` | user (or implicit — fresh unlabelled issues are treated as if they had this) | Untouched. Stage 1 will pick this up. |
-| `state:in-progress` | Stage 1 (plan-exec, at start) | Plan-exec is working. |
-| `state:clarification-needed` | Stage 1 (clarify-issue) | **HUMAN GATE.** Question posted, waiting on user. Orchestrator skips. |
+| `state:needs-planning` | user (or implicit — fresh unlabelled issues are treated as if they had this) | Untouched. Stage 1 (or epic-decompose for `type:epic`) will pick this up. |
+| `state:in-progress` | Stage 1 (plan-exec) or epic-decompose (at start) | Working. |
+| `state:clarification-needed` | Stage 1 (clarify-issue) or epic-decompose (Q round) | **HUMAN GATE.** Question posted, waiting on user. Orchestrator skips. |
 | `state:tests-pending` | Stage 1 (at end, after commit) | Branch + commit ready, awaiting test-writer. |
 | `state:in-review` | Stage 2 (after tests green + PR opened) | Reviewer's turn. |
 | `state:needs-rework` | Stage 2 (test failure) or Stage 3 (review failure) | Back to Stage 1. |
+| `state:awaiting-decompose-approval` | epic-decompose (proposal round) | **HUMAN GATE.** Proposed child list posted; waiting on `/decompose-ok` and a flip back to `state:needs-planning`. |
+| `state:tracking` | epic-decompose (file-children round) | Epic parent — children filed; waits for them to all close. Coordinator (TBD) auto-closes the parent. |
 | `state:blocked` | Stage 3 or anyone manually | Stop. **HUMAN GATE.** Park reason in comment. |
 
 **Fresh issues are unlabelled.** New issues filed without any `state:*` label are treated as equivalent to `state:needs-planning` — Stage 1 (plan-exec) accepts them and applies the label as part of its initial flip to `state:in-progress`. The user does not need to manually label new issues.
 
 ### Type, priority, area (unchanged)
 
-`type:feat`, `type:fix`, `type:chore`, `type:refactor`
+`type:feat`, `type:fix`, `type:chore`, `type:refactor`, `type:epic` (decomposed by `epic-decompose`; never branched directly)
 `priority:high`, `priority:medium`, `priority:low`
 `area:bot`, `area:vocab`, `area:scheduler`, `area:llm`, `area:translator`, `area:config`, `area:db`
 
@@ -121,6 +158,7 @@ Three skills under `.claude/skills/`. Each is auto-loaded in any Claude session 
 
 | Skill | Stage | Session | Outputs |
 |---|---|---|---|
+| `epic-decompose` | pre-1 (`type:epic` only) | Fresh per round | Q comment, proposal comment, or filed child issues + `state:tracking`. |
 | `plan-exec` | 1 | Combined plan + implement | Branch + commit; label flip; or clarification comment. Folds the old `plan-issue` skill's role into the implementer. |
 | `clarify-issue` | sub-skill of 1 | — | Posts a focused question, flips label, stops. Already exists; minor wording. |
 | `test-writer` | 2 | Fresh | Tests under `tests/`, pushed branch, opened PR; or rework comment. |
@@ -190,6 +228,7 @@ All agents run on **Opus 4.7** (`claude-opus-4-7`), passed via `claude -p --mode
 
 ```
 scripts/
+  agent-epic-decompose.sh <issue#>   — pre-Stage-1 for type:epic (one round per call)
   agent-plan-exec.sh    <issue#>     — Stage 1, manual or orchestrated
   agent-test-write.sh   <issue#>     — Stage 2
   agent-review.sh       <issue#>     — Stage 3 (resolves PR from issue)


### PR DESCRIPTION
## Summary

- New pre-Stage-1 path for `type:epic` issues: a dedicated `epic-decompose` skill that runs multi-round Socratic Q&A (one round per dispatch), proposes a child-issue list, awaits explicit `/decompose-ok` approval, then files the children with `Refs #<parent>` so they enter the regular plan-exec → test-writer → reviewer pipeline normally.
- Three new labels: `type:epic`, `state:awaiting-decompose-approval`, `state:tracking`. `agent-plan-exec.sh` now refuses `type:epic` so a misfire can't send a big feature into Stage 1.
- Auto-close-parent-when-children-done coordinator is intentionally **out of scope** — it's orchestrator-layer work and ships separately. Until then, the user closes the parent manually after the last child merges.

## Files

- `+ .claude/skills/epic-decompose/SKILL.md` — decision tree, Q/Propose/File-children sub-flows, `/decompose-ok` semantics, round cap (8 Qs).
- `+ scripts/agent-epic-decompose.sh` — runner mirroring the existing `agent-*.sh` pattern.
- `M scripts/setup-labels.sh` — adds the three new labels.
- `M scripts/agent-plan-exec.sh` — `type:epic` guard.
- `M workflow.md` — Epic decomposition section, updated state-label and skills tables.

## Test plan

- [ ] `bash scripts/setup-labels.sh` — verify the three new labels appear at `https://github.com/<owner>/<repo>/labels`.
- [ ] File a `type:epic` issue (e.g. "interactive vocab game"). Run `scripts/agent-epic-decompose.sh <#>` — expect a Q-round comment + state flip to `state:clarification-needed`.
- [ ] Answer the question in a comment, flip label back to `state:needs-planning`, run again — expect either another Q or a proposal.
- [ ] After a proposal lands, comment `/decompose-ok`, flip `state:awaiting-decompose-approval` → `state:needs-planning`, run again — expect children to be filed with `Refs #<parent>` and parent to flip to `state:tracking`.
- [ ] Misfire check: run `scripts/agent-plan-exec.sh` against a `type:epic` issue — expect exit code 2 with a hint pointing to `agent-epic-decompose.sh`.
- [ ] Pytest still green (`python -m pytest -q`) — no python changes, just sanity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)