### PR TITLE
feat: persist per-row translation, eager at /add + startup backfill

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -354,6 +354,20 @@ async def cmd_add(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     normalized = text.strip().lower()
     if added:
+        # Eagerly translate so future games never need a network call.
+        # Failure here mustn't block the user-facing reply — backfill on next
+        # bot start will pick up any rows still NULL.
+        settings = config_flow.load_settings(conn, chat_id)
+        target = settings.target_lang if settings is not None else "ru"
+        try:
+            translation = await asyncio.to_thread(
+                translator.translate, normalized, target
+            )
+            vocab.set_translation(conn, chat_id, normalized, translation)
+        except Exception as e:  # noqa: BLE001
+            log.warning(
+                "cmd_add: translate %r → %r failed: %s", normalized, target, e
+            )
         await update.message.reply_text(f"➕ Added: {normalized}")
     else:
         await update.message.reply_text(f"Already in your vocab: {normalized}")
@@ -826,6 +840,19 @@ async def _post_init(application: Application) -> None:
     runner.start()
     runner.refresh_all()
     log.info("Scheduler started; refreshed jobs for all known chats.")
+    # One-shot translation backfill for rows added before the column existed
+    # (or whose previous translate attempt failed). Network-bound, so offload.
+    counts = await asyncio.to_thread(
+        vocab.backfill_translations,
+        conn,
+        translate_fn=translator.translate,
+        log=log,
+    )
+    if counts["translated"] or counts["failed"]:
+        log.info(
+            "Translation backfill: translated=%d failed=%d",
+            counts["translated"], counts["failed"],
+        )
     # Populate Telegram's native command menu so clients show autocomplete.
     await application.bot.set_my_commands(
         [BotCommand(name, desc) for name, desc in COMMANDS]

--- a/db.py
+++ b/db.py
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS words (
     reps           INTEGER NOT NULL DEFAULT 0,
     lapses         INTEGER NOT NULL DEFAULT 0,
     last_review    TEXT,
+    translation    TEXT,
     UNIQUE(chat_id, text),
     FOREIGN KEY(chat_id) REFERENCES chats(chat_id) ON DELETE CASCADE
 );
@@ -86,3 +87,6 @@ def init_db(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE chats ADD COLUMN translate_target TEXT NOT NULL DEFAULT 'ru'"
         )
+    if "translation" not in _column_names(conn, "words"):
+        # NULL means "not yet translated" — backfilled by the startup sweep.
+        conn.execute("ALTER TABLE words ADD COLUMN translation TEXT")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -83,3 +83,41 @@ def test_words_default_fsrs_state_is_new(conn: sqlite3.Connection) -> None:
     assert row["state"] == 0
     assert row["stability"] is None
     assert row["difficulty"] is None
+
+
+# --- words.translation column (issue #63) -----------------------------------
+
+
+def _word_columns(conn: sqlite3.Connection) -> dict[str, dict]:
+    rows = conn.execute("PRAGMA table_info(words)").fetchall()
+    return {r["name"]: {"type": r["type"], "notnull": r["notnull"]} for r in rows}
+
+
+def test_words_has_translation_column_after_init(conn: sqlite3.Connection) -> None:  # AC1 — translation column exists, TEXT, NULL allowed
+    cols = _word_columns(conn)
+    assert "translation" in cols, f"expected translation column, got {sorted(cols)}"
+    assert cols["translation"]["type"].upper() == "TEXT", (
+        f"expected TEXT, got {cols['translation']['type']!r}"
+    )
+    assert cols["translation"]["notnull"] == 0, "translation must allow NULL"
+
+
+def test_words_translation_default_is_null(conn: sqlite3.Connection) -> None:  # AC1 — fresh insert leaves translation NULL
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'placid', '2026-04-21')"
+    )
+    row = conn.execute("SELECT translation FROM words").fetchone()
+    assert row["translation"] is None
+
+
+def test_init_db_translation_migration_idempotent(tmp_path: Path) -> None:  # AC1 — second init_db must not raise
+    path = tmp_path / "vocab.db"
+    c = db_mod.connect(path)
+    db_mod.init_db(c)
+    db_mod.init_db(c)
+    cols = _word_columns(c)
+    assert "translation" in cols
+    c.close()

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 
 import pytest
@@ -14,6 +15,23 @@ CHAT = 100
 
 def _all_words(conn: sqlite3.Connection) -> list[str]:
     return [r["text"] for r in conn.execute("SELECT text FROM words").fetchall()]
+
+
+def _set_chat_target(conn: sqlite3.Connection, chat_id: int, target: str) -> None:
+    vocab.ensure_chat(conn, chat_id)
+    conn.execute(
+        "UPDATE chats SET translate_target = ? WHERE chat_id = ?", (target, chat_id)
+    )
+
+
+def _translation_for(
+    conn: sqlite3.Connection, chat_id: int, text: str
+) -> str | None:
+    row = conn.execute(
+        "SELECT translation FROM words WHERE chat_id = ? AND text = ?",
+        (chat_id, text),
+    ).fetchone()
+    return None if row is None else row["translation"]
 
 
 def test_count_words_is_per_chat(conn: sqlite3.Connection) -> None:
@@ -320,3 +338,229 @@ def test_csv_round_trip_preserves_words() -> None:
     words = ["apple", "banana split", "cherry"]
     serialized = vocab.format_csv(words)
     assert sorted(vocab.parse_csv_words(serialized)) == sorted(words)
+
+
+# --- set_translation (issue #63) -------------------------------------------
+
+
+def test_set_translation_writes_for_existing_row(conn: sqlite3.Connection) -> None:  # AC3 — persist for matching row
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.set_translation(conn, CHAT, "apple", "яблоко")
+    assert _translation_for(conn, CHAT, "apple") == "яблоко"
+
+
+def test_set_translation_normalizes_text_for_lookup(conn: sqlite3.Connection) -> None:  # AC3 — _normalize gates the WHERE
+    vocab.add_word(conn, CHAT, "apple")
+    # Pre-norm whitespace + casing must still target the same row.
+    vocab.set_translation(conn, CHAT, "  APPLE  ", "яблоко")
+    assert _translation_for(conn, CHAT, "apple") == "яблоко"
+
+
+def test_set_translation_noop_when_row_missing(conn: sqlite3.Connection) -> None:  # AC3 — never raises for missing row
+    # No add_word call: there is no matching row in this chat.
+    vocab.ensure_chat(conn, CHAT)
+    vocab.set_translation(conn, CHAT, "ghost", "призрак")  # must not raise
+    row = conn.execute(
+        "SELECT 1 FROM words WHERE chat_id = ? AND text = 'ghost'", (CHAT,)
+    ).fetchone()
+    assert row is None, "set_translation must not insert"
+
+
+def test_set_translation_does_not_disturb_other_chats(conn: sqlite3.Connection) -> None:  # AC3 — chat_id scopes the UPDATE
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT + 1, "apple")
+    vocab.set_translation(conn, CHAT, "apple", "яблоко")
+    assert _translation_for(conn, CHAT, "apple") == "яблоко"
+    assert _translation_for(conn, CHAT + 1, "apple") is None, (
+        "translation must scope to chat_id"
+    )
+
+
+# --- backfill_translations (issue #63) -------------------------------------
+
+
+def test_backfill_translates_only_null_rows(conn: sqlite3.Connection) -> None:  # AC2 — NULL rows get translated
+    _set_chat_target(conn, CHAT, "ru")
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT, "banana")
+
+    counts = vocab.backfill_translations(
+        conn, translate_fn=lambda text, target: f"{text}->{target}"
+    )
+
+    assert counts == {"translated": 2, "failed": 0}
+    assert _translation_for(conn, CHAT, "apple") == "apple->ru"
+    assert _translation_for(conn, CHAT, "banana") == "banana->ru"
+
+
+def test_backfill_leaves_non_null_rows_untouched(conn: sqlite3.Connection) -> None:  # AC2 — pre-translated rows are skipped
+    _set_chat_target(conn, CHAT, "ru")
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.set_translation(conn, CHAT, "apple", "preset")
+    vocab.add_word(conn, CHAT, "banana")  # NULL
+
+    seen: list[tuple[str, str]] = []
+
+    def fake_translate(text: str, target: str) -> str:
+        seen.append((text, target))
+        return f"{text}!"
+
+    counts = vocab.backfill_translations(conn, translate_fn=fake_translate)
+
+    assert counts == {"translated": 1, "failed": 0}, f"got {counts}"
+    assert seen == [("banana", "ru")], (
+        f"translate_fn must only be called for NULL rows; got {seen}"
+    )
+    assert _translation_for(conn, CHAT, "apple") == "preset"
+    assert _translation_for(conn, CHAT, "banana") == "banana!"
+
+
+def test_backfill_uses_per_chat_translate_target(conn: sqlite3.Connection) -> None:  # AC2 — edge: multiple chats different targets
+    _set_chat_target(conn, CHAT, "ru")
+    _set_chat_target(conn, CHAT + 1, "es")
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT + 1, "apple")
+
+    counts = vocab.backfill_translations(
+        conn, translate_fn=lambda text, target: f"{text}-{target}"
+    )
+
+    assert counts == {"translated": 2, "failed": 0}
+    assert _translation_for(conn, CHAT, "apple") == "apple-ru"
+    assert _translation_for(conn, CHAT + 1, "apple") == "apple-es"
+
+
+def test_backfill_swallows_per_row_exception(conn: sqlite3.Connection) -> None:  # AC2 — per-row failure leaves row NULL, sweep continues
+    _set_chat_target(conn, CHAT, "ru")
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT, "banana")
+    vocab.add_word(conn, CHAT, "cherry")
+
+    def flaky(text: str, target: str) -> str:
+        if text == "banana":
+            raise RuntimeError("boom")
+        return f"{text}-{target}"
+
+    counts = vocab.backfill_translations(conn, translate_fn=flaky)
+
+    assert counts == {"translated": 2, "failed": 1}, f"got {counts}"
+    assert _translation_for(conn, CHAT, "apple") == "apple-ru"
+    assert _translation_for(conn, CHAT, "banana") is None, (
+        "failed row must remain NULL"
+    )
+    assert _translation_for(conn, CHAT, "cherry") == "cherry-ru"
+
+
+def test_backfill_logs_warning_when_logger_provided(
+    conn: sqlite3.Connection, caplog: pytest.LogCaptureFixture
+) -> None:  # AC2 — error path: log.warning emitted for failures
+    _set_chat_target(conn, CHAT, "ru")
+    vocab.add_word(conn, CHAT, "apple")
+
+    log = logging.getLogger("test_backfill_warns")
+
+    def boom(text: str, target: str) -> str:
+        raise RuntimeError("nope")
+
+    with caplog.at_level(logging.WARNING, logger=log.name):
+        counts = vocab.backfill_translations(conn, translate_fn=boom, log=log)
+
+    assert counts == {"translated": 0, "failed": 1}
+    assert any(
+        rec.levelno == logging.WARNING for rec in caplog.records
+    ), f"expected a WARNING record, got {[r.levelname for r in caplog.records]}"
+
+
+def test_backfill_no_logger_swallows_exception_silently(
+    conn: sqlite3.Connection,
+) -> None:  # AC2 — log=None must be safe
+    _set_chat_target(conn, CHAT, "ru")
+    vocab.add_word(conn, CHAT, "apple")
+
+    counts = vocab.backfill_translations(
+        conn,
+        translate_fn=lambda t, target: (_ for _ in ()).throw(RuntimeError("x")),
+    )
+
+    assert counts == {"translated": 0, "failed": 1}
+
+
+def test_backfill_returns_zero_for_empty_words(conn: sqlite3.Connection) -> None:  # edge: empty words table
+    counts = vocab.backfill_translations(
+        conn, translate_fn=lambda text, target: "should-not-be-called"
+    )
+    assert counts == {"translated": 0, "failed": 0}
+
+
+def test_backfill_no_op_when_all_translated(conn: sqlite3.Connection) -> None:  # edge: every row already populated
+    _set_chat_target(conn, CHAT, "ru")
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.set_translation(conn, CHAT, "apple", "preset")
+
+    calls: list[tuple[str, str]] = []
+
+    counts = vocab.backfill_translations(
+        conn,
+        translate_fn=lambda text, target: calls.append((text, target)) or "x",
+    )
+
+    assert counts == {"translated": 0, "failed": 0}
+    assert calls == [], f"translate_fn must not be called; got {calls}"
+    assert _translation_for(conn, CHAT, "apple") == "preset"
+
+
+# --- add_words_bulk translations parameter (issue #63) ---------------------
+
+
+def test_add_words_bulk_default_translations_are_null(
+    conn: sqlite3.Connection,
+) -> None:  # AC4 — translations=None leaves all NULL (existing call sites)
+    counts = vocab.add_words_bulk(conn, CHAT, ["apple", "banana"])
+    assert counts == {"added": 2, "skipped": 0, "invalid": 0}
+    assert _translation_for(conn, CHAT, "apple") is None
+    assert _translation_for(conn, CHAT, "banana") is None
+
+
+def test_add_words_bulk_with_translations_stores_each(
+    conn: sqlite3.Connection,
+) -> None:  # AC4 — parallel translations attach to new rows
+    counts = vocab.add_words_bulk(
+        conn,
+        CHAT,
+        ["apple", "banana"],
+        translations=["яблоко", "банан"],
+    )
+    assert counts == {"added": 2, "skipped": 0, "invalid": 0}
+    assert _translation_for(conn, CHAT, "apple") == "яблоко"
+    assert _translation_for(conn, CHAT, "banana") == "банан"
+
+
+def test_add_words_bulk_translations_length_mismatch_raises(
+    conn: sqlite3.Connection,
+) -> None:  # AC4 — error: ValueError on len mismatch
+    with pytest.raises(ValueError):
+        vocab.add_words_bulk(
+            conn, CHAT, ["apple", "banana"], translations=["only-one"]
+        )
+
+
+def test_add_words_bulk_drops_translation_for_within_batch_dup(
+    conn: sqlite3.Connection,
+) -> None:  # AC4 — edge: in-batch duplicate's translation is discarded
+    counts = vocab.add_words_bulk(
+        conn,
+        CHAT,
+        ["apple", "apple", "banana"],
+        translations=["t1", "t2", "t3"],
+    )
+    assert counts == {"added": 2, "skipped": 1, "invalid": 0}, f"got {counts}"
+    # First "apple" wins; "t2" must not overwrite "t1".
+    assert _translation_for(conn, CHAT, "apple") == "t1"
+    assert _translation_for(conn, CHAT, "banana") == "t3"
+
+
+def test_add_words_bulk_empty_with_empty_translations(
+    conn: sqlite3.Connection,
+) -> None:  # AC4 — edge: empty input + empty translations
+    counts = vocab.add_words_bulk(conn, CHAT, [], translations=[])
+    assert counts == {"added": 0, "skipped": 0, "invalid": 0}

--- a/vocab.py
+++ b/vocab.py
@@ -19,10 +19,12 @@ import csv
 import datetime
 import html
 import io
+import logging
 import math
 import random
 import re
 import sqlite3
+from typing import Callable
 
 from fsrs import Card, Rating, Scheduler, State
 
@@ -91,7 +93,10 @@ def add_word(conn: sqlite3.Connection, chat_id: int, text: str) -> bool:
 
 
 def add_words_bulk(
-    conn: sqlite3.Connection, chat_id: int, words: list[str]
+    conn: sqlite3.Connection,
+    chat_id: int,
+    words: list[str],
+    translations: list[str | None] | None = None,
 ) -> dict[str, int]:
     """Bulk-add words. Returns a count breakdown.
 
@@ -99,26 +104,94 @@ def add_words_bulk(
     Returns `{"added": N, "skipped": M, "invalid": K}` where `skipped` covers
     both pre-existing rows and within-input duplicates (both manifest as
     `INSERT OR IGNORE` no-ops).
+
+    `translations`, when given, is a parallel list aligned to `words`. Each new
+    row gets its translation; for skipped/invalid rows the translation slot is
+    discarded. When `translations` is None (default) every new row's
+    translation column is NULL — populated lazily by the startup backfill.
     """
+    if translations is not None and len(translations) != len(words):
+        raise ValueError(
+            f"translations length {len(translations)} does not match "
+            f"words length {len(words)}"
+        )
     ensure_chat(conn, chat_id)
     added = 0
     skipped = 0
     invalid = 0
     now = _now()
-    for raw in words:
+    for i, raw in enumerate(words):
         normalized = _normalize(raw)
         if not normalized:
             invalid += 1
             continue
+        translation = translations[i] if translations is not None else None
         cur = conn.execute(
-            "INSERT OR IGNORE INTO words(chat_id, text, added_at) VALUES (?, ?, ?)",
-            (chat_id, normalized, now),
+            "INSERT OR IGNORE INTO words(chat_id, text, added_at, translation) "
+            "VALUES (?, ?, ?, ?)",
+            (chat_id, normalized, now, translation),
         )
         if cur.rowcount > 0:
             added += 1
         else:
             skipped += 1
     return {"added": added, "skipped": skipped, "invalid": invalid}
+
+
+def set_translation(
+    conn: sqlite3.Connection, chat_id: int, text: str, translation: str
+) -> None:
+    """Update the translation column for `(chat_id, normalized(text))`.
+
+    No-ops when no row matches — callers don't need to know whether the row
+    still exists.
+    """
+    word = _normalize(text)
+    if not word:
+        return
+    conn.execute(
+        "UPDATE words SET translation = ? WHERE chat_id = ? AND text = ?",
+        (translation, chat_id, word),
+    )
+
+
+def backfill_translations(
+    conn: sqlite3.Connection,
+    *,
+    translate_fn: Callable[[str, str], str],
+    log: logging.Logger | None = None,
+) -> dict[str, int]:
+    """Translate every `words` row whose translation is still NULL.
+
+    Each row is translated using its chat's `translate_target` (joined from
+    `chats`). Per-row exceptions are caught, logged via `log.warning(...)` if
+    `log` is provided, counted under `failed`, and do not abort the sweep.
+    Returns `{"translated": N, "failed": M}`.
+    """
+    rows = conn.execute(
+        "SELECT w.id, w.text, c.translate_target "
+        "FROM words w JOIN chats c ON w.chat_id = c.chat_id "
+        "WHERE w.translation IS NULL"
+    ).fetchall()
+    translated = 0
+    failed = 0
+    for row in rows:
+        try:
+            result = translate_fn(row["text"], row["translate_target"])
+        except Exception as exc:  # noqa: BLE001 — keep the sweep alive
+            if log is not None:
+                log.warning(
+                    "backfill_translations: %r → %r failed: %s",
+                    row["text"], row["translate_target"], exc,
+                )
+            failed += 1
+            continue
+        conn.execute(
+            "UPDATE words SET translation = ? WHERE id = ?",
+            (result, row["id"]),
+        )
+        translated += 1
+    return {"translated": translated, "failed": failed}
 
 
 def parse_csv_words(text: str) -> list[str]:


### PR DESCRIPTION
Closes #63

## Summary
- Adds a forward-only `words.translation TEXT` column, gated on `_column_names()` so re-running `init_db` is a no-op.
- Eagerly populates new rows in `cmd_add` via `vocab.set_translation` and `translator.translate` wrapped in `asyncio.to_thread`; failures stay quiet for the user and are logged.
- One-time startup sweep `vocab.backfill_translations` translates every row whose `translation IS NULL`, using each chat's `translate_target` and swallowing per-row exceptions.
- `add_words_bulk` grows an optional parallel `translations` list so the next child (#64) can hand translations through.

## Test plan
- [x] Stage 2 added unit tests covering AC1–AC4 (migration shape, `set_translation` seam incl. normalization + chat scoping, `backfill_translations` happy path / per-row failure / per-chat target / empty cases / log warning, `add_words_bulk` with translations incl. length mismatch + within-batch dup).
- [x] \`pytest\` is green (268 passing).