### PR TITLE
feat: auto-deploy + deploy-diagnose (agent-fabric integration)

### DIFF
--- a/.claude/skills/deploy-diagnose/SKILL.md
+++ b/.claude/skills/deploy-diagnose/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: deploy-diagnose
+description: Use this skill when the fabric dispatches you against a failed deployment — the prompt will carry a JSON bundle with the failed sha, journal tail, and workflow run URL. Read the bundle, compare against `docs/deploy.md` and the commits since the last good deploy, hypothesise the single most likely root cause, and file ONE GitHub issue that the existing pipeline can pick up. Do not attempt to fix the code yourself.
+version: 1.0.0
+---
+
+# deploy-diagnose
+
+Read a failed deployment bundle and file one well-labeled GitHub issue with a concrete root-cause hypothesis. Triggered automatically when a deploy workflow POSTs to `/api/projects/<n>/deploy-failures`, or manually via `fabric diagnose <project> <deployment-id>`.
+
+You are the *first responder*, not the fix author. The issue you file is what `plan-exec` will read next; your output's quality determines whether the fix is one PR or three.
+
+## When to invoke
+
+The fabric calls you. You don't decide. The prompt arrives carrying a JSON bundle with these fields:
+
+- `deployment_id` — primary key of the failed `deployments` row
+- `project` — managed-project name
+- `failed_sha` / `failed_short_sha` — the commit the deploy was attempting
+- `previous_good_sha` / `previous_good_short_sha` — the last commit known to have deployed cleanly (may be `null` on first-ever deploy)
+- `deployed_at` — UTC ISO timestamp of the failure
+- `service_unit` — the systemd unit the workflow was restarting (e.g. `teach-me-eng-bot.service`)
+- `workflow_run_url` — link to the GitHub Actions run that captured the failure
+- `journal_tail` — last ~100 lines of `journalctl -u <unit>` from the moment of failure (may be `null` if the workflow couldn't capture it)
+
+## What to read
+
+In this order. Stop early when you have enough.
+
+1. **The bundle in your prompt.** Note the failed sha and journal tail.
+2. **`docs/deploy.md`** in the project root. This is the project's hand-maintained deploy contract: system deps, env vars, service topology, known failure modes. Cross-reference against `journal_tail`.
+3. **`git log --no-merges <previous_good_sha>..<failed_sha>`** (or just `git log -10` if `previous_good_sha` is null). One of these commits is almost certainly the cause.
+4. **The diff for the suspect commits** — `git show <sha>` or `git diff <previous_good_sha>..<failed_sha> -- <file>` for the specific files implicated by `journal_tail`.
+5. **The full workflow log**, if `journal_tail` is ambiguous: `gh run view <run-id> --log -R <project>` — extract the run-id from the tail of `workflow_run_url`.
+
+You can read more if you have to (the `gh` CLI gives you access to the merged PR, related issues, etc.) but resist the temptation to read everything. A skim of the right four files beats a deep read of twenty.
+
+## What to write
+
+**Exactly one GitHub issue.** No PRs, no comments on existing issues, no labels flipped on anything but the new issue.
+
+```bash
+gh issue create -R <owner>/<repo> \
+  --title "<see title format below>" \
+  --body "$(cat <<'EOF'
+<see body template below>
+EOF
+)" \
+  --label "state:needs-planning" \
+  --label "priority:high" \
+  --label "type:bug" \
+  --label "area:deploy"
+```
+
+If the project's repo doesn't yet have `area:deploy` as a label, omit that label and note in the body that it should be added — `fabric setup-labels <project>` after updating the project's `area_labels` config picks it up. Do not block on the label being absent.
+
+### Title format
+
+`deploy-failure: <one-line cause summary>`
+
+Concrete, scannable. Not "Deploy broke" — write "missing redis dependency causes ModuleNotFoundError on startup" or "PYTHONPATH change in 8d3a2f1 breaks bot.py import". Reading the title alone should tell a future operator what happened.
+
+### Body template
+
+```markdown
+## Failure
+
+Deploy of `<failed_short_sha>` failed during smoke check on <deployed_at UTC>.
+Workflow run: <workflow_run_url>
+
+## Hypothesised root cause
+
+<One paragraph. Name the suspect commit by short-sha. Quote the relevant
+journal line(s). Tie the journal evidence to the diff in that commit.>
+
+## Evidence
+
+- **Journal:** `<verbatim 1–3 most damning lines>`
+- **Commit:** `<short_sha> <subject line>` introduced `<file>:<line>` —
+  `<one-line description of what changed>`
+- **Why it broke:** <one sentence linking the commit to the journal line>
+
+## Suggested fix
+
+<One paragraph. Concrete change, not a vague "investigate". If genuinely
+unsure between two fixes, name both and ask the user to pick.>
+
+## Repro
+
+1. Check out `<failed_sha>` on the host.
+2. `<the systemd command the workflow ran>`
+3. Watch `journalctl -u <service_unit>` — error appears within ~30s.
+
+---
+*Filed automatically by `deploy-diagnose` against deployment #<deployment_id>. The current production version is whatever was running BEFORE this failure (no auto-rollback) — see `GET /api/projects/<project>/deployments/latest`.*
+```
+
+## Hard rules
+
+- **One issue per failure.** Even if the root cause is genuinely two-fold, file one issue with both threads. Don't fragment.
+- **Always pick a single most-likely commit.** "It could be 4 things" is useless to plan-exec. If genuinely impossible to narrow down, say so explicitly in the body and *still* name the most-suspicious one as a starting point.
+- **Use short shas in prose** (`abc1234`) and full shas only in `gh` arguments / `git` commands that need exactness. Issue bodies are read by humans; long shas hurt scannability.
+- **Quote, don't paraphrase, journal lines.** Two errors that look similar may be very different at the byte level. Plan-exec needs the exact error text to grep for it.
+- **No code blocks of >40 lines.** Trim journal output to the 1–3 lines that actually pin the cause. The full log is at `workflow_run_url` if anyone needs it.
+- **Don't speculate about fixes you can't justify.** "Could be a race condition" without evidence is noise. If the journal shows `ModuleNotFoundError: redis`, the fix is "add redis to requirements.txt" — not "audit all dependencies".
+- **Don't open the issue if `previous_good_sha == failed_sha`.** That means you're being asked to diagnose a deploy that should be a no-op; flag it as a workflow bug instead by printing a one-line summary to stdout and exiting non-zero.
+- **Don't run the deploy yourself, ever.** No `systemctl restart`, no `git push`, no `gh run rerun`. Read-only on the host.
+
+## After you file
+
+1. Print the issue URL to stdout — the dispatcher's log captures it for the dashboard / TG notification.
+2. Stop. The fabric scheduler picks the new issue up on the next tick (within 60s); plan-exec dispatches; the fix lands; the deploy workflow re-fires; if it succeeds, the loop closes itself.
+
+If the fix-PR's deploy *also* fails, you'll be invoked again for the new failure. Each invocation is independent — don't try to remember prior runs. The deployment_id is the unit of work.

--- a/.claude/skills/epic-decompose/SKILL.md
+++ b/.claude/skills/epic-decompose/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: epic-decompose
-description: Pre-Stage-1 skill for issues labelled `type:epic`. Runs headless from `scripts/agent-epic-decompose.sh` on a single epic and decomposes it into a set of child issues that the regular plan-exec → test-writer → reviewer pipeline can ship. Multi-round Socratic Q&A with the user across many invocations (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files the children with `Refs #<parent>`, and parks the parent at `state:tracking`. Does NOT cut branches, write code, or open PRs.
-version: 1.0.0
+description: Decomposition stage for `type:epic` issues at `state:needs-decompose`. Multi-round Socratic Q&A with the user (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files children with `Refs #<parent>`, and parks the parent at `state:tracking`. Children are filed B3-style — child #1 at `state:needs-planning`, the rest at `state:draft` — so the fabric's coordinator can release them one at a time as each predecessor closes. Considers documentation impact during decomposition so the epic doesn't close with stale docs. Does NOT cut branches, write code, or open PRs.
+version: 2.1.0
 ---
 
 # epic-decompose
 
-Decomposition stage for big features. Splits a `type:epic` parent issue into smaller child issues that the existing pipeline can ship one at a time. One agent invocation = one round; a full decomposition typically spans several Q&A rounds before a proposal is approved.
+Decomposition stage for `type:epic` parents. Splits the epic into smaller child issues that the existing pipeline ships one at a time, in the order you propose. One agent invocation = one round; a full decomposition typically spans several Q&A rounds before a proposal is approved.
 
 ## Hard boundaries
 
@@ -22,14 +22,12 @@ You MUST NOT:
 
 ## Inputs and exit conditions
 
-Dispatched at one of two states:
-- `state:needs-planning` — the entry/resume state. Either the first round, or the user resumed after a clarification answer or feedback on a proposal.
-- `state:awaiting-decompose-approval` — defensive; the runner script accepts this too. In practice the user flips back to `needs-planning` when they want the next dispatch to act.
+Dispatched on a `type:epic` parent at `state:needs-decompose`. That's the entry state on the very first dispatch (set by `qualify-issue`) and also the resume state after the user answers a clarification or asks for proposal revisions.
 
-Exits the run by flipping to one of:
+Exits the run by flipping the state label to one of:
 - `state:clarification-needed` — you posted a question, awaiting answer.
 - `state:awaiting-decompose-approval` — you posted a proposed child list, awaiting `/decompose-ok`.
-- `state:tracking` — children filed, parent now waits for them to merge.
+- `state:tracking` — children filed, parent now waits for them to merge. The fabric's coordinator advances child #2 to planning when child #1 closes, and so on; when the last child closes the parent auto-closes too.
 - `state:blocked` — round cap exhausted or unresolvable error (rare).
 
 ## The decision tree (do this every dispatch)
@@ -54,7 +52,7 @@ Read the issue body and **all** comments. Then walk this tree top-down — first
 
 ```bash
 gh issue edit <N> \
-  --remove-label "state:needs-planning,state:awaiting-decompose-approval" \
+  --remove-label "state:needs-decompose,state:awaiting-decompose-approval" \
   --add-label "state:in-progress"
 ```
 
@@ -78,7 +76,7 @@ gh issue comment <N> --body "$(cat <<'EOF'
 
 Context: <one sentence — what you've already concluded, what depends on this>.
 
-When you answer, flip the label back to `state:needs-planning` to re-enter the loop.
+When you answer, flip the label back to `state:needs-decompose` to re-enter the loop.
 EOF
 )"
 ```
@@ -121,7 +119,7 @@ gh issue comment <N> --body "$(cat <<'EOF'
 
 ---
 
-**Reply `/decompose-ok` to approve.** Then flip `state:awaiting-decompose-approval` → `state:needs-planning` and the next dispatch will file these as child issues. To request changes, comment your feedback and flip back to `state:needs-planning` — I'll revise.
+**Reply `/decompose-ok` to approve.** Then flip `state:awaiting-decompose-approval` → `state:needs-decompose` and the next dispatch will file these as child issues. To request changes, comment your feedback and flip back to `state:needs-decompose` — I'll revise.
 EOF
 )"
 ```
@@ -138,11 +136,23 @@ Print `proposal posted: <N> children, awaiting approval` and exit.
 
 **Sizing rule of thumb.** Aim for 3–8 children. Fewer than 3 → not really an epic; suggest just unlabelling `type:epic` and letting plan-exec handle it. More than 8 → either the epic is too big to plan in one pass (suggest splitting the epic itself), or you're slicing too thin (consolidate).
 
+**Docs hygiene (when applicable).** If the epic adds, removes, or renames user-facing surface — slash commands, `/help` text, README sections, in-app banners, `/start` onboarding flow, configuration env vars, public CLI flags — the documentation needs to land somewhere. Two acceptable shapes:
+- **Trailing `type:docs` child** — a small, focused child at the end of the sequence that updates README + `/help` + any onboarding copy in one PR. Use this when the docs touch multiple files or when several feature children touch the same surface.
+- **Doc touch-ups inside feature children** — fold the docs work into the relevant feature child's acceptance criteria (e.g. AC: `/help` lists the new command). Use this when the docs change is small and tightly coupled to one feature.
+
+Either is fine. The sin is letting the epic auto-close with stale docs because no child owned them. If the epic is purely internal (refactor, infra, test coverage) — no user-facing surface change — say so explicitly in the proposal's "One-line shape" and skip the docs child.
+
 ## 4. File-children round (after `/decompose-ok`)
 
-Triggered when §A1 of the decision tree matches. For each child in the most recent proposal, in the order you listed them:
+Triggered when §A1 of the decision tree matches. For each child in the most recent proposal, **in the order you listed them**:
+
+- The **first** child gets `state:needs-planning` — that's the one the pipeline will pick up immediately.
+- Every **subsequent** child gets `state:draft` — held until its predecessor closes. The fabric's coordinator (in `scheduler.py`) detects each child's closure, parses `Refs #<parent>` from its body, and flips the next `state:draft` sibling to `state:needs-planning` automatically. When the last child closes, the parent auto-closes too.
+
+The `Refs #<N>` line in the body is **load-bearing** — the coordinator parses it. Don't drop it, don't reword it.
 
 ```bash
+# Child #1 — the kick-off:
 gh issue create \
   --title "<imperative title>" \
   --label "type:feat,priority:medium,area:vocab,state:needs-planning" \
@@ -160,6 +170,24 @@ Part of epic #<N>.
 Refs #<N>
 EOF
 )"
+
+# Children #2..K — held until their predecessor closes:
+gh issue create \
+  --title "<imperative title>" \
+  --label "type:feat,priority:medium,area:vocab,state:draft" \
+  --body "$(cat <<EOF
+<one-paragraph problem statement>
+
+## Acceptance criteria
+- AC1: ...
+
+## Out of scope
+- ...
+
+Part of epic #<N>.
+Refs #<N>
+EOF
+)"
 ```
 
 Capture each new issue number from the URL `gh issue create` prints. Then post one closing comment on the parent that lists the child links and flip to `state:tracking`:
@@ -167,13 +195,14 @@ Capture each new issue number from the URL `gh issue create` prints. Then post o
 ```bash
 gh issue comment <N> --body "$(cat <<EOF
 <!-- agent-decompose-filed v1 -->
-**Decomposition filed.** Children:
+**Decomposition filed.** Children (will be released one at a time as each predecessor closes):
 
-- #<C1> — <title>
-- #<C2> — <title>
+- #<C1> — <title> · `state:needs-planning` (active)
+- #<C2> — <title> · `state:draft` (held)
+- #<C3> — <title> · `state:draft` (held)
 - ...
 
-Parent will auto-close once all children are closed (orchestrator coordinator).
+The fabric will advance the next held child to `state:needs-planning` automatically when each closes. Parent auto-closes once the last child is done.
 EOF
 )"
 
@@ -183,8 +212,6 @@ gh issue edit <N> \
 ```
 
 Print `filed <K> children for epic #<N>: <numbers>` and exit.
-
-> **Coordinator caveat:** the auto-close-on-children-done coordinator lives in the orchestrator (separate increment). Until that ships, the parent stays at `state:tracking` and the user closes it manually after all children merge. Mention this in the closing comment if the orchestrator is not yet deployed.
 
 ## 5. What "must-answer" questions look like for an epic
 
@@ -198,6 +225,7 @@ A non-exhaustive checklist of the kinds of unknowns to clear before proposing. W
 - **Test seams.** Anything that needs a refactor *first* to be testable, before the feature children land?
 - **External services / config.** New env vars? New API keys? Quotas?
 - **Naming.** Names of new commands, modules, labels — pick *or* ask.
+- **User-facing docs.** Which docs (README, `/help` command output, in-app banners, `/start` onboarding) describe the surface this epic touches? Are they out-of-date or generic enough to survive without changes? If non-trivial, the docs deserve their own child (or an explicit AC on the relevant feature child) — see "Docs hygiene" in §3.
 
 ## After-the-loop notes
 

--- a/.claude/skills/qualify-issue/SKILL.md
+++ b/.claude/skills/qualify-issue/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: qualify-issue
+description: Triage stage for freshly-filed open issues that have no `state:*` label. Reads the body and routes the issue into one of four buckets — `state:draft` (ignored), `type:epic` + `state:needs-decompose` (decompose), `state:clarification-needed` (ask the human), or `state:needs-planning` (ready for plan-exec) — by setting labels and, where appropriate, a single short comment. Read-and-label only; never edits code, never opens PRs, never touches more than one issue per dispatch.
+version: 1.1.0
+---
+
+# qualify-issue
+
+The first thing the fabric does to any new issue. One dispatch = one classification = one terminal `state:*` label set on the issue.
+
+## Hard boundaries
+
+You MAY:
+- `gh issue view`, `gh issue list` (read-only on other issues for cross-reference resolution).
+- `gh issue comment`, `gh issue edit` (labels) **on the issue you were dispatched on**.
+- Read code with the `Read` / `Grep` tools to ground a scope estimate.
+
+You MUST NOT:
+- Edit code, create branches, commit, push, or open PRs. Triage is read-and-label only.
+- Touch any issue other than the one you were dispatched on.
+- Apply more than one `state:*` label.
+- Skip applying a state label. Every dispatch must end with the issue holding exactly one `state:*` label so the next tick knows what to do.
+- Apply `priority:*` or `type:*` you cannot defend from the body. When in doubt, leave them off — the next stage or the human will tag them.
+
+## Inputs
+
+You're dispatched on an open issue with **no** `state:*` label on GitHub. The fabric tags it `state:unqualified` internally — that label is not on GitHub, you don't need to remove anything before applying the real one.
+
+## The decision tree
+
+Walk top-down. **First match wins** — once a branch fires, set its labels and stop.
+
+### Branch 1 — Draft / WIP
+
+Match if **any**:
+- The body or title contains "WIP", "draft", "not ready", "do not work on", "ignore for now", "[WIP]", "[draft]", or equivalent.
+- The body explicitly says the author is still drafting / thinking out loud.
+
+```bash
+gh issue edit <N> --add-label "state:draft"
+gh issue comment <N> --body "Marked as \`state:draft\` — agents will skip this issue. Remove the label when it's ready to work."
+```
+
+Stop.
+
+### Branch 2 — Vague / unanswerable
+
+Match if **all** of these hold even after re-reading the body and skimming related code:
+- You cannot state in one sentence what the change is supposed to *do*.
+- Two reasonable interpretations of the body would lead to different module changes.
+- The issue contradicts itself, or asks for two unrelated things in the same body.
+
+If yes, ask **one focused question** and park.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-qualify v1 -->
+**Quick triage question before I queue this for planning:**
+
+<the precise question — one paragraph, one decision>
+
+Context: <one sentence — the load-bearing ambiguity, in your own words>.
+
+Reply on the issue or via Telegram. Once you answer, remove `state:clarification-needed` and the next tick will re-triage.
+EOF
+)"
+gh issue edit <N> --add-label "state:clarification-needed"
+```
+
+Stop. Do not also set `priority:*` or `type:*` — they may change after the answer.
+
+The bar for asking is high. **You are not the planner.** Plan-exec will ask its own clarification later if needed. Ask only when the issue body is so under-specified that *any* attempt at a plan would be guesswork.
+
+### Branch 3 — Epic
+
+Match if **any** of these are clearly true from the body:
+- The author explicitly calls it an "epic", "big feature", "multi-step initiative", or asks to "split into smaller issues".
+- Implementation would obviously require **3+ separate PRs** to ship safely (e.g. new module + new schema + new UI + migration; multi-stage rollout with feature flags).
+- The body lists 4+ acceptance criteria across **different concerns** (not 4 sub-checks of one thing — the test for "different concerns" is whether each criterion lives in a different module).
+
+Most issues are **not epics.** A single feature, a bug fix, a refactor, a docs update, even a moderate cross-module change — these are plan-ready, not epics. Bias toward Branch 4. Reach for "epic" only when splitting it would be obviously wrong to do in a single PR.
+
+```bash
+gh issue edit <N> --add-label "type:epic" --add-label "state:needs-decompose"
+gh issue comment <N> --body "Classified as \`type:epic\` + \`state:needs-decompose\` — \`epic-decompose\` will pick this up to start the Q&A and propose a child-issue list."
+```
+
+Stop. `type:epic` is the permanent marker on the parent (separates "what kind of issue" from "where in the pipeline"); `state:needs-decompose` is the transient routing state the scheduler keys on. Don't also set `type:feature` — `type:epic` covers it.
+
+### Branch 4 — Plan-ready (default)
+
+This is the **default branch** if 1–3 didn't fire. Use it whenever the issue is a single-deliverable change with enough detail for plan-exec to draft a plan, even if some details are fuzzy.
+
+```bash
+gh issue edit <N> --add-label "state:needs-planning"
+# Add priority + type only if you can defend the choice from the body.
+# When unsure, leave them off — plan-exec or the human will set them.
+```
+
+No comment is required for this branch. Quietness on the plan-ready path keeps the issue thread clean for the actual planning work.
+
+#### Inferring `priority:*` (optional)
+
+| Body signal | Label |
+|---|---|
+| "ASAP", "urgent", security risk, broken feature blocking other work | `priority:high` |
+| Quality-of-life, tech debt, "nice to have", small UX, docs | `priority:low` |
+| Anything else | `priority:medium` (or leave unset) |
+
+Don't infer `priority:high` from author tone alone — look for a concrete reason.
+
+#### Inferring `type:*` (optional)
+
+| Body signal | Label |
+|---|---|
+| "fix", "broken", "doesn't work", reproducible defect | `type:bug` |
+| "add", "support for", new capability | `type:feature` |
+| "rename", "move", "clean up", "extract" with no behavior change | `type:refactor` |
+| README, docstring, /help text, `*.md` | `type:docs` |
+| Test coverage, fixtures | `type:test` |
+
+#### Inferring `area:*` (optional)
+
+If the issue body or title clearly references one of the project's `area:*` labels (each project's `.fabric/config.yaml` lists the valid set), apply it. Cross-cutting issues may take 2+ area labels. Skip if uncertain.
+
+## Worked examples
+
+These are sketches based on real issue shapes — actual classification will vary with the full body.
+
+**Title: "Rewrite README. Leave only information about this bot's functionality"**
+→ Branch 4. `state:needs-planning` + `priority:low` + `type:docs`. Single deliverable, scope is clear.
+
+**Title: "Need ability to upload words by batches"** (body: use case, mentions import/export as a stretch)
+→ Branch 4. `state:needs-planning` + `type:feature`. Borderline epic? No — one user-facing capability with one input format. Plan-exec can scope import/export as a follow-up if needed.
+
+**Title: "Update /help command descriptions"** (body: "we just completed #49 but /help wasn't updated; please fix")
+→ Branch 4. `state:needs-planning` + `priority:medium` + `type:docs`. Cross-references another issue but is itself a single small change.
+
+**Title: "Potential security risk"** (body: notes that `ALLOWED_USER_IDS` is empty in some tested branch, suggests this might let anyone use the bot)
+→ Branch 4. `state:needs-planning` + `priority:high` + `type:bug`. A defect with a concrete reproducer and a real consequence.
+
+**Title: "Migrate auth + storage + UI to multi-tenant"** (body: lists 6 ACs spanning DB schema, OAuth, frontend, new admin pages, billing, docs)
+→ Branch 3. `type:epic` + `state:needs-decompose`. 3+ PRs, different concerns. epic-decompose takes it from here.
+
+**Title: "Refactor"** (body: empty)
+→ Branch 2. Ask: "What part of the codebase, and what's wrong with the current shape that motivates the refactor?" Cannot reasonably plan from this.
+
+**Title: "[WIP] Thinking about a new vocab review mode"**
+→ Branch 1. `state:draft`. The `[WIP]` tag is the signal.
+
+## Output discipline
+
+Every dispatch ends with **one** of:
+
+- A label edit + a short comment (Branches 1, 2, 3).
+- A label edit only (Branch 4).
+
+That's it. Do not post your reasoning, do not narrate the decision tree you walked, do not summarize the issue back at the user. The whole skill exists to keep new issues moving without making the human read your scratch work.
+
+## Failure handling
+
+- If the issue was closed between dispatch and your read: silently exit. The fabric's closure-detection path will handle the bookkeeping on the next tick.
+- If `gh issue edit` fails for a label that doesn't exist on the project: the project hasn't yet run `fabric setup-labels`. Comment the label name + this fact, and exit. The fabric will retry on the next tick.
+- If you genuinely cannot decide between two branches after re-reading: prefer Branch 2 (ask one question) over guessing. The cost of one Q&A round is one tick.

--- a/.fabric/config.yaml
+++ b/.fabric/config.yaml
@@ -1,0 +1,64 @@
+# Example .fabric/config.yaml for teach-me-eng-bot.
+#
+# When this file lives at <teach-me-eng-bot>/.fabric/config.yaml,
+# `fabric sync teach-me-eng-bot` reproduces the project's current
+# .claude/skills/{plan-exec,test-writer,review-pr,clarify-issue,epic-decompose}/SKILL.md
+# byte-for-byte. dev-flow/ is project-internal and not touched by sync.
+
+project:
+  name: teach-me-eng-bot
+  repo: valdisd96/teach-me-eng-bot
+  trusted_authors: [valdisd96]
+
+build:
+  setup_cmd: "source .venv/bin/activate"
+  test_cmd: "python -m pytest -q"
+  lint_cmd: null
+
+modules:
+  - path: bot.py
+    role: "python-telegram-bot wiring + handlers + scheduler bootstrap"
+  - path: vocab.py
+    role: "vocab CRUD, mention scanning, FSRS rating, weighted-random select_word"
+  - path: scheduler.py
+    role: "push planning + APScheduler runner"
+  - path: llm.py
+    role: "Anthropic SSE wrapper + prompt assembly"
+  - path: translator.py
+    role: "EN/RU translation for /translate"
+  - path: db.py
+    role: "SQLite schema + migrations"
+  - path: config_flow.py
+    role: "/start onboarding state machine"
+  - path: prompts.py
+    role: "Anthropic prompt templates"
+  - path: sysinfo.py
+    role: "/status diagnostic output"
+
+safety:
+  blocked_paths:
+    - .github/workflows/**
+    - teach-me-eng-bot.service
+    - install-service.sh
+  destructive_db_patterns:
+    - "DROP COLUMN"
+    - "DROP TABLE"
+    - "ALTER COLUMN .* DROP"
+  notes: |
+    db.py migrations may add columns but never drop. FSRS columns
+    (stability, difficulty, state, step, due, reps, lapses, last_review)
+    are load-bearing and must not be touched.
+
+labels:
+  state_prefix: "state:"
+  type_prefix: "type:"
+  area_prefix: "area:"
+  area_labels: [bot, vocab, scheduler, llm, translator, config, db]
+
+pipeline:
+  cycle_limit: 5
+  retry_count: 3
+  retry_backoff_seconds: [60, 300, 900]
+  daily_dispatch_cap: 30
+
+fabric_version: "0.1.0"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,166 @@
+# Auto-deploy teach-me-eng-bot on push to `main`.
+#
+# Generated from agent-fabric's template at examples/github-actions/deploy.yml.
+# See `docs/deploy.md` for the deploy contract this workflow implements, and
+# DESIGN.md "Decision 15 — Deployment of managed projects" in the agent-fabric
+# repo for the rationale (no auto-rollback; failures self-heal via the
+# deploy-diagnose skill that fabric auto-dispatches).
+#
+# Required host setup (one-time, see deploy-setup.md in agent-fabric):
+#   - A repo-scoped self-hosted runner registered to valdisd96/teach-me-eng-bot
+#     with labels `self-hosted, deploy-target` (and ideally `teach-me-eng-bot`).
+#   - `/var/lib/teach-me-eng-bot/` owned by the runner user.
+#   - `github-runner` has passwordless sudo (already true on the fabric VM).
+#
+# Optional repo secrets (workflow degrades cleanly when unset):
+#   - FABRIC_DEPLOY_URL: e.g. http://127.0.0.1:7878 — base URL of the fabric.
+#   - FABRIC_TOKEN: bearer token sent to fabric's deploy endpoints.
+
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PROJECT_NAME: teach-me-eng-bot
+  INSTALL_DIR: /root/teach-me-eng-bot
+  SERVICE_UNIT: teach-me-eng-bot.service
+  REQUIREMENTS_FILE: requirements.txt
+  # No pre-restart migrations: db.py::init_db() handles schema inline at
+  # process start. Add a script and set this if you ever need an out-of-band
+  # backfill — see docs/deploy.md "Migrations".
+  MIGRATE_SCRIPT: ""
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, deploy-target]
+    concurrency:
+      # Queue concurrent deploys; do not cancel an in-flight one. Latest wins.
+      group: deploy-${{ github.workflow }}
+      cancel-in-progress: false
+
+    steps:
+      - name: pull latest into install dir
+        run: |
+          set -euo pipefail
+          sudo -n git -C "$INSTALL_DIR" fetch --quiet origin main
+          sudo -n git -C "$INSTALL_DIR" reset --hard "$GITHUB_SHA"
+          echo "host now at $(sudo -n git -C "$INSTALL_DIR" rev-parse --short HEAD)"
+
+      - name: refresh venv if requirements changed
+        run: |
+          set -euo pipefail
+          if [ -z "${REQUIREMENTS_FILE:-}" ] || ! sudo -n test -f "$INSTALL_DIR/$REQUIREMENTS_FILE"; then
+            echo "no requirements file declared — skipping venv refresh"
+            exit 0
+          fi
+          new_hash="$(sudo -n sha256sum "$INSTALL_DIR/$REQUIREMENTS_FILE" | awk '{print $1}')"
+          live_hash="$(sudo -n cat "$INSTALL_DIR/.venv/.requirements.sha256" 2>/dev/null || echo none)"
+          if [ "$live_hash" = "$new_hash" ]; then
+            echo "requirements unchanged ($new_hash) — reusing venv"
+            exit 0
+          fi
+          echo "requirements changed (was ${live_hash:0:12}, now ${new_hash:0:12}) — rebuilding venv"
+          sudo -n bash -eu -c "
+            cd '$INSTALL_DIR'
+            rm -rf .venv
+            python3 -m venv .venv
+            .venv/bin/pip install --quiet --upgrade pip
+            .venv/bin/pip install --quiet -r '$REQUIREMENTS_FILE'
+            echo '$new_hash' > .venv/.requirements.sha256
+          "
+
+      - name: run migrations if present
+        run: |
+          set -euo pipefail
+          if [ -n "${MIGRATE_SCRIPT:-}" ] && sudo -n test -x "$INSTALL_DIR/$MIGRATE_SCRIPT"; then
+            echo "running $MIGRATE_SCRIPT"
+            sudo -n "$INSTALL_DIR/$MIGRATE_SCRIPT"
+          else
+            echo "no migration script — skipping"
+          fi
+
+      - name: restart service
+        run: sudo -n systemctl restart "$SERVICE_UNIT"
+
+      - name: smoke check
+        run: |
+          set -euo pipefail
+          sleep 8
+          if ! sudo -n systemctl is-active --quiet "$SERVICE_UNIT"; then
+            echo "::error::$SERVICE_UNIT is not active after restart"
+            sudo -n journalctl -u "$SERVICE_UNIT" -n 200 --no-pager
+            exit 1
+          fi
+          if sudo -n journalctl -u "$SERVICE_UNIT" --since '60 seconds ago' --no-pager \
+              | grep -E '\b(ERROR|CRITICAL|Traceback)\b' >&2; then
+            echo "::error::error pattern in journal within 60s of restart"
+            exit 1
+          fi
+          echo "service healthy"
+
+      - name: write deploy manifest
+        if: success()
+        run: |
+          set -euo pipefail
+          ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          short_sha="${GITHUB_SHA:0:7}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > "/var/lib/$PROJECT_NAME/deploy.json" <<EOF
+          {
+            "sha": "$GITHUB_SHA",
+            "short_sha": "$short_sha",
+            "deployed_at": "$ts",
+            "branch": "$GITHUB_REF_NAME",
+            "actor": "$GITHUB_ACTOR",
+            "workflow_run_url": "$run_url"
+          }
+          EOF
+          echo "wrote /var/lib/$PROJECT_NAME/deploy.json"
+
+      - name: notify fabric (success)
+        if: success()
+        env:
+          FABRIC_DEPLOY_URL: ${{ secrets.FABRIC_DEPLOY_URL }}
+          FABRIC_TOKEN: ${{ secrets.FABRIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FABRIC_DEPLOY_URL:-}" ]; then
+            echo "FABRIC_DEPLOY_URL not set — skipping fabric notification (bootstrap mode)"
+            exit 0
+          fi
+          curl --silent --fail --max-time 10 \
+            -H "Authorization: Bearer $FABRIC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d @"/var/lib/$PROJECT_NAME/deploy.json" \
+            "$FABRIC_DEPLOY_URL/api/projects/$PROJECT_NAME/deployments"
+
+      - name: notify fabric (failure)
+        if: failure()
+        env:
+          FABRIC_DEPLOY_URL: ${{ secrets.FABRIC_DEPLOY_URL }}
+          FABRIC_TOKEN: ${{ secrets.FABRIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FABRIC_DEPLOY_URL:-}" ]; then
+            echo "FABRIC_DEPLOY_URL not set — skipping fabric notification (bootstrap mode)"
+            exit 0
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          journal_tail="$(sudo -n journalctl -u "$SERVICE_UNIT" --since '5 minutes ago' --no-pager 2>&1 | tail -100 || echo '<no journal>')"
+          payload="$(jq -n \
+            --arg sha "$GITHUB_SHA" \
+            --arg run_url "$run_url" \
+            --arg unit "$SERVICE_UNIT" \
+            --arg journal "$journal_tail" \
+            '{sha: $sha, status: "failed", workflow_run_url: $run_url, service_unit: $unit, journal_tail: $journal}')"
+          curl --silent --fail --max-time 10 \
+            -H "Authorization: Bearer $FABRIC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$FABRIC_DEPLOY_URL/api/projects/$PROJECT_NAME/deploy-failures"

--- a/.github/workflows/fabric-sync-check.yml
+++ b/.github/workflows/fabric-sync-check.yml
@@ -1,0 +1,47 @@
+# Drift check for fabric-managed skills.
+#
+# Generated from agent-fabric's example at
+# `examples/github-actions/fabric-sync-check.yml`. Pinned to a specific
+# agent-fabric commit; bump AGENT_FABRIC_SHA below intentionally to adopt
+# fabric updates (template changes ripple to every managed project on next sync).
+#
+# Fails the build when the project's `.claude/skills/` files don't match
+# what `fabric sync .` would render against `.fabric/config.yaml` right now —
+# i.e. someone hand-edited a rendered skill instead of updating the template
+# in agent-fabric (or a project-local overlay under `.fabric/skills/`).
+#
+# To resolve a failure: edit the source template in agent-fabric, run
+# `fabric sync teach-me-eng-bot` locally, commit the regenerated files.
+
+name: fabric sync drift check
+
+on:
+  pull_request:
+    paths:
+      - '.fabric/**'
+      - '.claude/skills/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v4
+
+      - name: set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: install agent-fabric
+        env:
+          AGENT_FABRIC_SHA: ac2adf3dc881023e0f63780840016a8ac42a45dc
+        run: |
+          pip install "agent-fabric @ git+https://github.com/valdisd96/agent-fabric.git@${AGENT_FABRIC_SHA}"
+
+      - name: check skills are synced
+        run: fabric sync . --check

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,112 @@
+# Deploy contract
+
+This document is the canonical reference for how `teach-me-eng-bot` runs in production. The fabric's `deploy-diagnose` skill reads this file when it's triaging a deploy failure — keeping it accurate makes diagnoses faster and more precise. Hand-maintain it as part of any change that touches deploy surface (a new env var, a new system dep, a new background process).
+
+## Overview
+
+The bot is a single long-running Python 3.12 process that polls Telegram via long-polling and (by default) talks to a remote OpenAI-compatible chat completions endpoint. SQLite is the only persistent store. There are no other services, no message broker, no reverse proxy.
+
+```
+┌───────────────────────────────┐
+│  teach-me-eng-bot.service     │
+│  systemd unit, single process │
+│                               │
+│  python bot.py                │
+│   ├─ python-telegram-bot       │  ──long-poll──▶  api.telegram.org
+│   ├─ APScheduler (in-process) │
+│   ├─ httpx                    │  ──HTTPS────▶   openrouter.ai (or local LLM)
+│   ├─ deep-translator          │  ──HTTPS────▶   translate.google.com
+│   └─ sqlite3                  │  ──fs──────▶   data/vocab.db
+└───────────────────────────────┘
+```
+
+No inbound HTTP. No public ports. Outbound HTTPS only.
+
+## Host requirements
+
+- **OS**: Linux. Tested on Ubuntu 24.04. The systemd unit + python venv layout assumes a glibc-based distro.
+- **Python**: 3.12 (or any version supported by the dependencies in `requirements.txt`). `python3 -m venv` is required.
+- **System packages**: `python3.12`, `python3.12-venv`, `sqlite3` (for ad-hoc inspection; the bot itself uses the stdlib `sqlite3` module). Nothing else.
+- **No native build deps** — all Python deps in `requirements.txt` ship as wheels.
+
+## Service topology
+
+A single systemd unit defined at `teach-me-eng-bot.service` (committed at the repo root):
+
+```ini
+[Service]
+User=root
+WorkingDirectory=/root/teach-me-eng-bot
+EnvironmentFile=/root/teach-me-eng-bot/.env
+ExecStart=/root/teach-me-eng-bot/.venv/bin/python bot.py
+Restart=on-failure
+RestartSec=5
+```
+
+- **User**: `root`. The bot's working dir, venv, and SQLite live under `/root/`. A future PR may relocate to `/srv/teach-me-eng-bot` and switch to a non-root user; until then, deploys run as root via `sudo -n` from the GitHub Actions self-hosted runner.
+- **WorkingDirectory**: `/root/teach-me-eng-bot`. The bot's `Path(__file__).resolve().parent` (in `bot.py`) anchors all relative paths to this directory, so a relocation is mostly mechanical.
+- **EnvironmentFile**: `/root/teach-me-eng-bot/.env` (mode 0600, owned by root, NOT in git). Loaded by systemd; the bot does not call `python-dotenv` from inside its working dir at runtime.
+- **Restart**: `on-failure` — a clean exit (e.g. SIGTERM) does NOT auto-restart; a crash does. `RestartSec=5` means a tight crash loop is rate-limited.
+
+## Environment variables
+
+The bot reads these via `os.environ` (loaded by systemd's `EnvironmentFile=`). They are documented for users in the project README; this list is the *deploy* angle — what happens if each is missing or wrong.
+
+| Variable | Required | Effect on startup |
+|---|---|---|
+| `TELEGRAM_TOKEN` | **Yes** | Unset or invalid → `python-telegram-bot` raises at the first `getMe` call within ~5s of process start. Look for `telegram.error.InvalidToken` or `Unauthorized` in journalctl. |
+| `LLM_BACKEND` | No (default `llama`) | `openrouter` routes chat through OpenRouter (production); anything else falls back to a local server on `http://127.0.0.1:8080`. A wrong value with no local server gives connection-refused on the first chat. |
+| `OPENROUTER_API_KEY` | When `LLM_BACKEND=openrouter` | Empty value with `LLM_BACKEND=openrouter` raises at the first LLM call (not at startup) — bot starts but every chat message fails. |
+| `OPENROUTER_MODEL` | No | Defaults to a free-tier model id; an unsupported value 4xxs at the first chat call. |
+| `SYSTEM_PROMPT` | No | Falls back to a sensible default; arbitrary string. |
+| `ALLOWED_USER_IDS` | No | Empty = allow all. Comma/whitespace-separated Telegram user ids; non-numeric tokens are silently ignored. |
+
+**Drift-checking convention**: when adding a new `os.environ.get(...)` or `os.getenv(...)` site to the codebase, mirror it in this table in the same PR. The diagnose skill cross-references journalctl errors against this table to identify "missing env var" failures fast.
+
+## Persistent state
+
+- **`/root/teach-me-eng-bot/data/vocab.db`** — primary SQLite database. Plus `vocab.db-shm` and `vocab.db-wal` (WAL-mode; survive restarts). Gitignored. **Must NOT be wiped on deploy.** The `git reset --hard` step in the deploy workflow does not touch gitignored files, so this is automatically preserved.
+- **`/root/teach-me-eng-bot/.env`** — secrets. Mode 0600, owner root, gitignored. Survives deploys for the same reason.
+- **`/root/teach-me-eng-bot/.venv/`** — Python virtualenv. Gitignored. Recreated only when `requirements.txt` changes (sha256-compared by the deploy workflow).
+- **`/root/teach-me-eng-bot/logs/`** — per-conversation transcripts (one file per chat, append-only). Gitignored; bounded only by chat volume. Manual rotation.
+- **`/var/lib/teach-me-eng-bot/deploy.json`** — deploy manifest written by the deploy workflow on every successful run. Owned by `github-runner`. The fabric's `GET /api/projects/teach-me-eng-bot/deployments/latest` reads this to surface "what's running".
+
+## Migrations
+
+There is **no `scripts/migrate.sh`**. SQLite schema changes happen inline in `db.py` via `init_db()` which runs at startup and is idempotent. The deploy workflow's `MIGRATE_SCRIPT` value is intentionally blank.
+
+If a future change needs an explicit pre-restart migration (e.g. a backfill that takes minutes and shouldn't run from inside `bot.py`), add `scripts/migrate.sh` (idempotent, exits non-zero on failure) and set `MIGRATE_SCRIPT: scripts/migrate.sh` in `.github/workflows/deploy.yml`. Update this section in the same PR.
+
+## Deploy flow
+
+Auto-triggered on push to `main`:
+
+1. **Self-hosted GitHub Actions runner** (registered to `valdisd96/teach-me-eng-bot`, label `deploy-target`) picks up the workflow.
+2. `sudo -n git -C /root/teach-me-eng-bot fetch && reset --hard <sha>` — gitignored files (`.env`, `data/`, `.venv/`, `logs/`) are preserved.
+3. **Conditional venv refresh**: hash-compare `requirements.txt` against `/root/teach-me-eng-bot/.venv/.requirements.sha256`. On change, `rm -rf .venv && python3 -m venv .venv && pip install -r requirements.txt`. Else reuse.
+4. `sudo -n systemctl restart teach-me-eng-bot.service`.
+5. **Smoke check** (8s grace + 60s journal scan): `systemctl is-active` must succeed AND `journalctl -u teach-me-eng-bot --since '60 seconds ago'` must be free of `ERROR`, `CRITICAL`, or `Traceback`.
+6. **On success** — write `/var/lib/teach-me-eng-bot/deploy.json`, POST manifest to fabric.
+7. **On failure** — POST failure bundle (sha + journal tail + workflow URL) to fabric. The previous broken version stays running (no auto-rollback). The fabric dispatches `deploy-diagnose`, which files a GH issue. The fix-PR's merge re-fires this workflow.
+
+The full workflow lives at `.github/workflows/deploy.yml`. The shape comes from `agent-fabric`'s template at `examples/github-actions/deploy.yml`.
+
+## Known failure modes
+
+A grab-bag of failures that have happened or are easy to imagine. The diagnose skill cross-references against this list when triaging.
+
+| Symptom in journalctl | Most likely cause | Fix |
+|---|---|---|
+| `telegram.error.InvalidToken` or `Unauthorized` at startup | `TELEGRAM_TOKEN` empty / rotated / pointed at the wrong bot | Re-fetch from `@BotFather`, update `/root/teach-me-eng-bot/.env`, `systemctl restart`. |
+| `ConnectionError` to `127.0.0.1:8080` early in journal | `LLM_BACKEND=llama` (default) but no local LLM running | Either start the local LLM, or set `LLM_BACKEND=openrouter` + `OPENROUTER_API_KEY` in `.env`. |
+| `httpx.HTTPStatusError 401` from OpenRouter at first chat | `OPENROUTER_API_KEY` rotated or empty | Refresh the key on openrouter.ai, update `.env`, `systemctl restart`. |
+| `ModuleNotFoundError: <package>` at startup | `requirements.txt` updated but `.venv` not refreshed | The deploy workflow's hash-compare should catch this — if it didn't, delete `/root/teach-me-eng-bot/.venv/.requirements.sha256` to force a rebuild on next deploy, OR `rm -rf .venv && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` manually. |
+| `sqlite3.OperationalError: no such table` | A code change references a table the schema doesn't have | Inspect `db.py::init_db()` — schema changes must be additive (CREATE TABLE IF NOT EXISTS, ALTER TABLE ADD COLUMN). DROP / rename are blocked by `safety.destructive_db_patterns` in `.fabric/config.yaml` and need explicit human override. |
+| `OSError: [Errno 28] No space left on device` | `data/`, `logs/`, or systemd journal filling the disk | `df -h /root` to confirm. The bot's transcripts in `logs/` grow unbounded; rotate. SQLite WAL can also balloon under heavy write — `sqlite3 data/vocab.db 'PRAGMA wal_checkpoint(TRUNCATE);'` releases it. |
+| Deploy succeeds but bot stops responding | The systemd unit may have started but failed to register webhooks / commands. Look for `telegram.error.NetworkError` or `Conflict: terminated by other getUpdates request`. The latter means a second instance is competing for long-polling — verify only one `bot.py` process is running. |
+
+## What this contract does NOT cover
+
+- **Zero-downtime deploys.** The `systemctl restart` step incurs a 2–5 second blip; for a single-user TG bot, this is acceptable. If multi-user load makes this matter, blue-green via two systemd units behind a routing layer is the path — not in scope today.
+- **Backups.** `data/vocab.db` is not currently backed up off-host. A user data loss recovery story is a separate concern.
+- **Multi-environment deploys** (staging, prod). One environment, one host, one deploy. Branching for env-specific config will need a second `.env` strategy.


### PR DESCRIPTION
## Summary

Closes the deploy loop. Pushing to `main` on this repo now redeploys automatically; on failure, the agent-fabric's `deploy-diagnose` skill reads the failure bundle + this repo's `docs/deploy.md` + `git log` since last good, then files a labelled GH issue that the existing pipeline picks up.

The corresponding agent-fabric work (workflow template, REST endpoints, `deploy-diagnose` skill template) shipped in `agent-fabric@ac2adf3`.

### Files added

| File | What |
|---|---|
| `.fabric/config.yaml` | Committed source of truth for the fabric renderer (was previously copied at deploy time per SMOKE.md). Byte-identical to `agent-fabric/examples/teach-me-eng-bot.config.yaml`. |
| `docs/deploy.md` | Hand-written deploy contract: host requirements, env vars, persistent state, known failure modes. Read by `deploy-diagnose` when triaging — keep accurate. |
| `.github/workflows/deploy.yml` | Auto-deploy on push to main via the repo-scoped self-hosted runner. No auto-rollback by design (DESIGN.md Decision 15 in agent-fabric). |
| `.github/workflows/fabric-sync-check.yml` | Drift gate, pinned to `agent-fabric@ac2adf3`. |
| `.claude/skills/deploy-diagnose/SKILL.md` | Rendered fresh from agent-fabric — what the fabric dispatches against deploy failures. |
| `.claude/skills/epic-decompose/SKILL.md` | Rendered fresh — was missing, fills out the fabric-managed skill set. |
| `.claude/skills/qualify-issue/SKILL.md` | Rendered fresh — was missing, fills out the fabric-managed skill set. |

## Why

Without this, every merge requires manual SSH + `git pull` + `systemctl restart`. With it, the fabric's `plan-exec → test-writer → review-pr → user-merges → deploy → diagnose-on-failure` loop is end-to-end automated for this project.

## Verification done locally

- `pytest -q` → 248 pass (existing suite untouched).
- `fabric sync . --check` → clean.
- `pytest tests/test_parity.py` in `agent-fabric` with `TEACH_ME_ENG_BOT_PATH=/root/teach-me-eng-bot` → all 7 fabric-managed skills match byte-for-byte (was 4/7 before this PR; the 3 new ones now have their expected files).
- YAML lint on both new workflow files → parses cleanly.

## Host setup still required (one-time, after merge)

These can't be scripted blindly — the operator runs them once on the fabric VM:

1. **Register a repo-scoped self-hosted runner** to `valdisd96/teach-me-eng-bot` with labels `self-hosted,deploy-target`. Org-scoped runners can't serve a personal repo.
2. `sudo install -d -o github-runner -g github-runner /var/lib/teach-me-eng-bot` — deploy manifest target.
3. *(Optional)* `gh secret set FABRIC_DEPLOY_URL -R valdisd96/teach-me-eng-bot --body "http://127.0.0.1:7878"` — wires fabric notifications. Without it, deploys still work; failures just don't auto-dispatch diagnose.

The full one-time runbook lives at `agent-fabric/examples/runbooks/deploy-setup.md`.

## Test plan

After merge + the host setup above:

- [ ] Open a trivial PR (e.g. README typo). Merge it.
- [ ] Watch `gh run watch -R valdisd96/teach-me-eng-bot` — workflow should complete green within ~15s.
- [ ] Confirm `/var/lib/teach-me-eng-bot/deploy.json` updated with new sha.
- [ ] If `FABRIC_DEPLOY_URL` set: `curl 127.0.0.1:7878/api/projects/teach-me-eng-bot/deployments/latest` should return the new sha.
- [ ] Open a deliberately broken PR (e.g. add a non-existent dep to `requirements.txt`). Merge it.
- [ ] Workflow should fail on smoke check.
- [ ] If fabric is wired: a new GH issue should appear in this repo within ~60s, labelled `state:needs-planning + priority:high + type:bug + area:deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)