### PR TITLE
Add labels + word_labels tables and DAO

### DIFF
--- a/db.py
+++ b/db.py
@@ -55,6 +55,24 @@ CREATE TABLE IF NOT EXISTS push_log (
     FOREIGN KEY(chat_id) REFERENCES chats(chat_id) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_push_log_chat ON push_log(chat_id);
+
+CREATE TABLE IF NOT EXISTS labels (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id  INTEGER NOT NULL,
+    name     TEXT    NOT NULL,
+    UNIQUE(chat_id, name),
+    FOREIGN KEY(chat_id) REFERENCES chats(chat_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_labels_chat ON labels(chat_id);
+
+CREATE TABLE IF NOT EXISTS word_labels (
+    word_id  INTEGER NOT NULL,
+    label_id INTEGER NOT NULL,
+    PRIMARY KEY(word_id, label_id),
+    FOREIGN KEY(word_id)  REFERENCES words(id)  ON DELETE CASCADE,
+    FOREIGN KEY(label_id) REFERENCES labels(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_word_labels_label ON word_labels(label_id);
 """
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -121,3 +121,184 @@ def test_init_db_translation_migration_idempotent(tmp_path: Path) -> None:  # AC
     cols = _word_columns(c)
     assert "translation" in cols
     c.close()
+
+
+# --- labels + word_labels schema (issue #82) -------------------------------
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> dict[str, dict]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {
+        r["name"]: {"type": r["type"], "notnull": r["notnull"], "pk": r["pk"]}
+        for r in rows
+    }
+
+
+def _foreign_keys(conn: sqlite3.Connection, table: str) -> list[dict]:
+    rows = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+    return [
+        {
+            "table": r["table"],
+            "from": r["from"],
+            "to": r["to"],
+            "on_delete": r["on_delete"],
+        }
+        for r in rows
+    ]
+
+
+def test_init_creates_labels_table(conn: sqlite3.Connection) -> None:  # AC1 — labels(id, chat_id, name) + UNIQUE + FK CASCADE
+    assert "labels" in _tables(conn), f"expected labels table, got {sorted(_tables(conn))}"
+
+    cols = _columns(conn, "labels")
+    assert "id" in cols and cols["id"]["pk"] == 1, f"id must be PK; got {cols.get('id')!r}"
+    assert "chat_id" in cols and cols["chat_id"]["notnull"] == 1, (
+        f"chat_id must be NOT NULL; got {cols.get('chat_id')!r}"
+    )
+    assert "name" in cols and cols["name"]["notnull"] == 1, (
+        f"name must be NOT NULL; got {cols.get('name')!r}"
+    )
+
+    # UNIQUE(chat_id, name): inserting the same (chat_id, name) twice must fail.
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    conn.execute("INSERT INTO labels(chat_id, name) VALUES (1, 'pos:noun')")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO labels(chat_id, name) VALUES (1, 'pos:noun')")
+
+    fks = _foreign_keys(conn, "labels")
+    chat_fk = next((fk for fk in fks if fk["from"] == "chat_id"), None)
+    assert chat_fk is not None, f"labels.chat_id must FK; got {fks!r}"
+    assert chat_fk["table"] == "chats", f"FK target must be chats, got {chat_fk!r}"
+    assert chat_fk["on_delete"].upper() == "CASCADE", (
+        f"labels.chat_id FK must ON DELETE CASCADE; got {chat_fk!r}"
+    )
+
+
+def test_init_creates_word_labels_table(conn: sqlite3.Connection) -> None:  # AC2 — word_labels(word_id, label_id) composite PK, FKs CASCADE
+    assert "word_labels" in _tables(conn), (
+        f"expected word_labels table, got {sorted(_tables(conn))}"
+    )
+
+    cols = _columns(conn, "word_labels")
+    assert "word_id" in cols and cols["word_id"]["pk"] >= 1, (
+        f"word_id must be part of PK; got {cols.get('word_id')!r}"
+    )
+    assert "label_id" in cols and cols["label_id"]["pk"] >= 1, (
+        f"label_id must be part of PK; got {cols.get('label_id')!r}"
+    )
+
+    # Composite PK: same (word_id, label_id) twice must fail.
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'apple', '2026-04-21')"
+    )
+    conn.execute("INSERT INTO labels(chat_id, name) VALUES (1, 'pos:noun')")
+    wid = conn.execute("SELECT id FROM words").fetchone()["id"]
+    lid = conn.execute("SELECT id FROM labels").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO word_labels(word_id, label_id) VALUES (?, ?)", (wid, lid)
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO word_labels(word_id, label_id) VALUES (?, ?)", (wid, lid)
+        )
+
+    fks = _foreign_keys(conn, "word_labels")
+    word_fk = next((fk for fk in fks if fk["from"] == "word_id"), None)
+    label_fk = next((fk for fk in fks if fk["from"] == "label_id"), None)
+    assert word_fk is not None and word_fk["table"] == "words", (
+        f"word_id must FK to words; got {fks!r}"
+    )
+    assert word_fk["on_delete"].upper() == "CASCADE", (
+        f"word_id FK must ON DELETE CASCADE; got {word_fk!r}"
+    )
+    assert label_fk is not None and label_fk["table"] == "labels", (
+        f"label_id must FK to labels; got {fks!r}"
+    )
+    assert label_fk["on_delete"].upper() == "CASCADE", (
+        f"label_id FK must ON DELETE CASCADE; got {label_fk!r}"
+    )
+
+
+def test_init_db_label_tables_idempotent(tmp_path: Path) -> None:  # AC3 — forward-only + idempotent: rows untouched, tables present
+    path = tmp_path / "vocab.db"
+    c = db_mod.connect(path)
+    db_mod.init_db(c)
+
+    # Seed the new tables so we can detect any data wipe across re-init.
+    c.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    c.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'apple', '2026-04-21')"
+    )
+    c.execute("INSERT INTO labels(chat_id, name) VALUES (1, 'pos:noun')")
+    wid = c.execute("SELECT id FROM words").fetchone()["id"]
+    lid = c.execute("SELECT id FROM labels").fetchone()["id"]
+    c.execute(
+        "INSERT INTO word_labels(word_id, label_id) VALUES (?, ?)", (wid, lid)
+    )
+
+    db_mod.init_db(c)  # second call must not raise or wipe data
+
+    assert {"labels", "word_labels"}.issubset(_tables(c))
+    assert c.execute("SELECT COUNT(*) AS n FROM labels").fetchone()["n"] == 1, (
+        "existing labels rows must survive re-init"
+    )
+    assert c.execute("SELECT COUNT(*) AS n FROM word_labels").fetchone()["n"] == 1, (
+        "existing word_labels rows must survive re-init"
+    )
+    c.close()
+
+
+def test_delete_word_cascades_to_word_labels(conn: sqlite3.Connection) -> None:  # AC6 — DELETE FROM words wipes word_labels rows
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (1, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (1, 'apple', '2026-04-21')"
+    )
+    conn.execute("INSERT INTO labels(chat_id, name) VALUES (1, 'pos:noun')")
+    wid = conn.execute("SELECT id FROM words").fetchone()["id"]
+    lid = conn.execute("SELECT id FROM labels").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO word_labels(word_id, label_id) VALUES (?, ?)", (wid, lid)
+    )
+
+    conn.execute("DELETE FROM words WHERE id = ?", (wid,))
+
+    assert conn.execute("SELECT COUNT(*) AS n FROM word_labels").fetchone()["n"] == 0, (
+        "word_labels rows must cascade-delete with their word"
+    )
+    # The label row itself should remain — only word_labels cascades from words.
+    assert conn.execute("SELECT COUNT(*) AS n FROM labels").fetchone()["n"] == 1, (
+        "deleting a word must NOT delete labels"
+    )
+
+
+def test_delete_chat_cascades_to_labels_and_word_labels(conn: sqlite3.Connection) -> None:  # AC6 — DELETE FROM chats wipes labels + word_labels transitively
+    conn.execute(
+        "INSERT INTO chats(chat_id, tz, created_at) VALUES (7, 'UTC', '2026-04-21')"
+    )
+    conn.execute(
+        "INSERT INTO words(chat_id, text, added_at) VALUES (7, 'apple', '2026-04-21')"
+    )
+    conn.execute("INSERT INTO labels(chat_id, name) VALUES (7, 'pos:noun')")
+    wid = conn.execute("SELECT id FROM words").fetchone()["id"]
+    lid = conn.execute("SELECT id FROM labels").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO word_labels(word_id, label_id) VALUES (?, ?)", (wid, lid)
+    )
+
+    conn.execute("DELETE FROM chats WHERE chat_id = 7")
+
+    assert conn.execute("SELECT COUNT(*) AS n FROM labels").fetchone()["n"] == 0, (
+        "labels must cascade-delete when their chat is removed"
+    )
+    assert conn.execute("SELECT COUNT(*) AS n FROM word_labels").fetchone()["n"] == 0, (
+        "word_labels must cascade transitively (via words and labels)"
+    )

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -708,3 +708,226 @@ def test_csv_round_trip_unicode_preserves_translations() -> None:  # edge: unico
 def test_format_csv_with_non_tuple_row_raises() -> None:  # error: non-2-tuple → propagates Python's natural unpacking error
     with pytest.raises((TypeError, ValueError)):
         vocab.format_csv(["apple"])  # type: ignore[list-item]
+
+
+# --- labels DAO (issue #82) -------------------------------------------------
+
+
+def _word_id(conn: sqlite3.Connection, chat_id: int, text: str) -> int:
+    return conn.execute(
+        "SELECT id FROM words WHERE chat_id = ? AND text = ?", (chat_id, text)
+    ).fetchone()["id"]
+
+
+def _label_rows(conn: sqlite3.Connection, chat_id: int) -> list[tuple[int, str]]:
+    return [
+        (r["id"], r["name"])
+        for r in conn.execute(
+            "SELECT id, name FROM labels WHERE chat_id = ? ORDER BY id", (chat_id,)
+        ).fetchall()
+    ]
+
+
+def test_get_or_create_label_creates_new_row(conn: sqlite3.Connection) -> None:  # AC4 — returns int id, inserts row
+    vocab.ensure_chat(conn, CHAT)
+    lid = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    assert isinstance(lid, int), f"expected int id, got {type(lid).__name__}"
+    rows = _label_rows(conn, CHAT)
+    assert rows == [(lid, "pos:noun")], f"expected one labels row; got {rows!r}"
+
+
+def test_get_or_create_label_is_idempotent(conn: sqlite3.Connection) -> None:  # AC4 + example — twice → same id, one row
+    vocab.ensure_chat(conn, CHAT)
+    first = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    second = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    assert first == second, f"ids must match across calls; got {first} vs {second}"
+    assert len(_label_rows(conn, CHAT)) == 1, (
+        f"second call must not insert a duplicate; got {_label_rows(conn, CHAT)!r}"
+    )
+
+
+def test_get_or_create_label_scoped_per_chat(conn: sqlite3.Connection) -> None:  # AC4 — same name in 2 chats → 2 distinct ids
+    vocab.ensure_chat(conn, CHAT)
+    vocab.ensure_chat(conn, CHAT + 1)
+    a = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    b = vocab.get_or_create_label(conn, CHAT + 1, "pos:noun")
+    assert a != b, f"per-chat labels must have distinct ids; got {a} == {b}"
+
+
+def test_attach_label_returns_true_for_new(conn: sqlite3.Connection) -> None:  # AC4 — fresh attach returns True
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    lid = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+    assert vocab.attach_label(conn, wid, lid) is True
+    assert vocab.labels_for_word(conn, wid) == ["type:medicine"]
+
+
+def test_attach_label_double_attach_returns_false(conn: sqlite3.Connection) -> None:  # edge — double-attach → False
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    lid = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+    vocab.attach_label(conn, wid, lid)
+    assert vocab.attach_label(conn, wid, lid) is False, (
+        "second attach of the same (word, label) must report False"
+    )
+    rows = conn.execute(
+        "SELECT COUNT(*) AS n FROM word_labels WHERE word_id = ? AND label_id = ?",
+        (wid, lid),
+    ).fetchone()
+    assert rows["n"] == 1, f"only one row should exist; got {rows['n']}"
+
+
+def test_attach_label_unknown_id_raises_keyerror(conn: sqlite3.Connection) -> None:  # error — unknown label_id → KeyError
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    with pytest.raises(KeyError):
+        vocab.attach_label(conn, wid, 999_999)
+
+
+def test_attach_pos_replaces_existing_pos_label(conn: sqlite3.Connection) -> None:  # AC5 + example — pos:verb after pos:noun keeps only pos:verb
+    vocab.add_word(conn, CHAT, "run")
+    wid = _word_id(conn, CHAT, "run")
+    noun = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    verb = vocab.get_or_create_label(conn, CHAT, "pos:verb")
+
+    assert vocab.attach_label(conn, wid, noun) is True
+    assert vocab.attach_label(conn, wid, verb) is True
+
+    assert vocab.labels_for_word(conn, wid) == ["pos:verb"], (
+        "attaching a second pos:* must detach the prior pos:* atomically"
+    )
+
+
+def test_attach_pos_leaves_non_pos_labels_alone(conn: sqlite3.Connection) -> None:  # AC5 — non-pos:* labels untouched by the pos-swap
+    vocab.add_word(conn, CHAT, "ibuprofen")
+    wid = _word_id(conn, CHAT, "ibuprofen")
+    noun = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    medicine = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+    verb = vocab.get_or_create_label(conn, CHAT, "pos:verb")
+
+    vocab.attach_label(conn, wid, noun)
+    vocab.attach_label(conn, wid, medicine)
+    vocab.attach_label(conn, wid, verb)
+
+    assert vocab.labels_for_word(conn, wid) == ["pos:verb", "type:medicine"], (
+        "swap must scope to pos:* only; non-pos labels must survive"
+    )
+
+
+def test_attach_pos_noop_when_same_already_attached(conn: sqlite3.Connection) -> None:  # edge — attaching pos:noun again → False, no other pos:* removed
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    noun = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    medicine = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+
+    vocab.attach_label(conn, wid, noun)
+    vocab.attach_label(conn, wid, medicine)
+
+    assert vocab.attach_label(conn, wid, noun) is False, (
+        "re-attaching the same pos:* must report False"
+    )
+    assert vocab.labels_for_word(conn, wid) == ["pos:noun", "type:medicine"], (
+        "re-attaching same pos:* must not strip other labels"
+    )
+
+
+def test_attach_pos_wipes_multiple_stray_pos_rows(conn: sqlite3.Connection) -> None:  # edge — multiple stray pos:* rows all wiped
+    vocab.add_word(conn, CHAT, "lead")
+    wid = _word_id(conn, CHAT, "lead")
+    noun = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    verb = vocab.get_or_create_label(conn, CHAT, "pos:verb")
+    adj = vocab.get_or_create_label(conn, CHAT, "pos:adj")
+    new_pos = vocab.get_or_create_label(conn, CHAT, "pos:adverb")
+
+    # Bypass the DAO to plant multiple stray pos:* rows (the DAO would reject this).
+    for lid in (noun, verb, adj):
+        conn.execute(
+            "INSERT INTO word_labels(word_id, label_id) VALUES (?, ?)", (wid, lid)
+        )
+
+    assert vocab.attach_label(conn, wid, new_pos) is True
+    assert vocab.labels_for_word(conn, wid) == ["pos:adverb"], (
+        "all stray pos:* rows must be wiped, leaving only the new pos:* label"
+    )
+
+
+def test_detach_label_returns_true_when_attached(conn: sqlite3.Connection) -> None:  # AC4 — detach returns True iff a row was deleted
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    lid = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+    vocab.attach_label(conn, wid, lid)
+
+    assert vocab.detach_label(conn, wid, lid) is True
+    assert vocab.labels_for_word(conn, wid) == []
+
+
+def test_detach_label_returns_false_when_absent(conn: sqlite3.Connection) -> None:  # edge — detach when not attached → False
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    lid = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+    # No attach — there is no row to delete.
+    assert vocab.detach_label(conn, wid, lid) is False
+
+
+def test_labels_for_word_returns_sorted_names(conn: sqlite3.Connection) -> None:  # AC4 — names sorted ascending
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    # Attach in non-alphabetic order; the call must still return them sorted.
+    for name in ("type:medicine", "pos:noun", "category:fruit"):
+        vocab.attach_label(conn, wid, vocab.get_or_create_label(conn, CHAT, name))
+
+    out = vocab.labels_for_word(conn, wid)
+    assert out == ["category:fruit", "pos:noun", "type:medicine"], f"got {out!r}"
+
+
+def test_words_matching_labels_and_semantics(conn: sqlite3.Connection) -> None:  # AC4 + example — only words tagged with all of names
+    for w in ("apple", "ibuprofen", "banana"):
+        vocab.add_word(conn, CHAT, w)
+    pos_noun = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    type_med = vocab.get_or_create_label(conn, CHAT, "type:medicine")
+
+    # apple: pos:noun only.        ibuprofen: pos:noun + type:medicine.   banana: type:medicine only.
+    vocab.attach_label(conn, _word_id(conn, CHAT, "apple"), pos_noun)
+    vocab.attach_label(conn, _word_id(conn, CHAT, "ibuprofen"), pos_noun)
+    vocab.attach_label(conn, _word_id(conn, CHAT, "ibuprofen"), type_med)
+    vocab.attach_label(conn, _word_id(conn, CHAT, "banana"), type_med)
+
+    rows = vocab.words_matching_labels(conn, CHAT, ["pos:noun", "type:medicine"])
+    texts = [r["text"] for r in rows]
+    assert texts == ["ibuprofen"], f"AND across labels must yield only ibuprofen; got {texts!r}"
+
+
+def test_words_matching_labels_dedupes_names(conn: sqlite3.Connection) -> None:  # edge — duplicate names in input are deduped
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT, "ibuprofen")
+    pos_noun = vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    vocab.attach_label(conn, _word_id(conn, CHAT, "apple"), pos_noun)
+    vocab.attach_label(conn, _word_id(conn, CHAT, "ibuprofen"), pos_noun)
+
+    rows = vocab.words_matching_labels(conn, CHAT, ["pos:noun", "pos:noun", "pos:noun"])
+    texts = sorted(r["text"] for r in rows)
+    assert texts == ["apple", "ibuprofen"], (
+        f"duplicate names must collapse — both noun-tagged words should appear once each; got {texts!r}"
+    )
+
+
+def test_words_matching_labels_empty_returns_all_in_list_words_order(
+    conn: sqlite3.Connection,
+) -> None:  # edge — empty names → every word for chat, ordered like list_words
+    vocab.add_word(conn, CHAT, "old_high")
+    vocab.add_word(conn, CHAT, "old_low")
+    vocab.add_word(conn, CHAT, "new_low")
+    vocab.add_word(conn, CHAT + 1, "other_chat_word")  # different chat — must not appear
+
+    conn.execute("UPDATE words SET mention_count = 5 WHERE text = 'old_high'")
+    conn.execute("UPDATE words SET added_at = '2020-01-01' WHERE text = 'old_low'")
+
+    rows = vocab.words_matching_labels(conn, CHAT, [])
+    matched = [r["text"] for r in rows]
+    expected = [r["text"] for r in vocab.list_words(conn, CHAT)]
+    assert matched == expected, (
+        f"empty names must reproduce list_words ordering; got {matched!r} vs {expected!r}"
+    )
+    assert "other_chat_word" not in matched, (
+        "rows must scope to chat_id; other chat's word leaked"
+    )

--- a/vocab.py
+++ b/vocab.py
@@ -474,3 +474,117 @@ def select_word(
     weights = [compute_weight(r, now) for r in rows]
     pick = (rng or random).choices(rows, weights=weights, k=1)
     return pick[0]
+
+
+# --- labels (per-chat many-to-many tags on words) ---------------------------
+
+POS_PREFIX = "pos:"
+
+
+def get_or_create_label(conn: sqlite3.Connection, chat_id: int, name: str) -> int:
+    """Return the id of `(chat_id, name)`, inserting the row if needed.
+
+    Idempotent: calling twice with the same `(chat_id, name)` returns the same
+    id and leaves a single row in `labels`.
+    """
+    cur = conn.execute(
+        "INSERT OR IGNORE INTO labels(chat_id, name) VALUES (?, ?)",
+        (chat_id, name),
+    )
+    if cur.rowcount > 0:
+        return cur.lastrowid
+    row = conn.execute(
+        "SELECT id FROM labels WHERE chat_id = ? AND name = ?",
+        (chat_id, name),
+    ).fetchone()
+    return row["id"]
+
+
+def attach_label(conn: sqlite3.Connection, word_id: int, label_id: int) -> bool:
+    """Attach `label_id` to `word_id`. Returns True iff a new row was inserted.
+
+    Raises `KeyError(label_id)` when the label does not exist.
+
+    Enforces the "one POS per word" rule: when the label's name starts with
+    `pos:`, any other `pos:*` row on this word is detached first. The
+    detach + insert run inside an explicit transaction so observers never see
+    a state where both old and new `pos:*` are simultaneously attached.
+    """
+    label = conn.execute(
+        "SELECT name FROM labels WHERE id = ?", (label_id,)
+    ).fetchone()
+    if label is None:
+        raise KeyError(label_id)
+    is_pos = label["name"].startswith(POS_PREFIX)
+    conn.execute("BEGIN")
+    try:
+        if is_pos:
+            conn.execute(
+                "DELETE FROM word_labels "
+                "WHERE word_id = ? "
+                "  AND label_id != ? "
+                "  AND label_id IN (SELECT id FROM labels WHERE name LIKE ?)",
+                (word_id, label_id, f"{POS_PREFIX}%"),
+            )
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO word_labels(word_id, label_id) VALUES (?, ?)",
+            (word_id, label_id),
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    return cur.rowcount > 0
+
+
+def detach_label(conn: sqlite3.Connection, word_id: int, label_id: int) -> bool:
+    """Detach `label_id` from `word_id`. Returns True iff a row was deleted."""
+    cur = conn.execute(
+        "DELETE FROM word_labels WHERE word_id = ? AND label_id = ?",
+        (word_id, label_id),
+    )
+    return cur.rowcount > 0
+
+
+def labels_for_word(conn: sqlite3.Connection, word_id: int) -> list[str]:
+    """Names of every label attached to `word_id`, sorted ascending."""
+    rows = conn.execute(
+        "SELECT l.name FROM labels l "
+        "JOIN word_labels wl ON wl.label_id = l.id "
+        "WHERE wl.word_id = ? "
+        "ORDER BY l.name ASC",
+        (word_id,),
+    ).fetchall()
+    return [r["name"] for r in rows]
+
+
+def words_matching_labels(
+    conn: sqlite3.Connection,
+    chat_id: int,
+    names: list[str],
+) -> list[sqlite3.Row]:
+    """Words for `chat_id` tagged with **all** of `names` (AND semantics).
+
+    Duplicate entries in `names` are deduped — `["pos:noun", "pos:noun"]`
+    matches the same words as `["pos:noun"]`. An empty `names` returns every
+    word for the chat (no filter). Result ordering matches `list_words`:
+    mention_count ASC, added_at DESC.
+    """
+    if not names:
+        return conn.execute(
+            "SELECT * FROM words WHERE chat_id = ? "
+            "ORDER BY mention_count ASC, added_at DESC",
+            (chat_id,),
+        ).fetchall()
+    unique_names = list(dict.fromkeys(names))
+    placeholders = ",".join("?" * len(unique_names))
+    return conn.execute(
+        f"SELECT w.* FROM words w "
+        f"JOIN word_labels wl ON wl.word_id = w.id "
+        f"JOIN labels l ON l.id = wl.label_id "
+        f"WHERE w.chat_id = ? AND l.chat_id = ? AND l.name IN ({placeholders}) "
+        f"GROUP BY w.id "
+        f"HAVING COUNT(DISTINCT l.name) = ? "
+        f"ORDER BY w.mention_count ASC, w.added_at DESC",
+        (chat_id, chat_id, *unique_names, len(unique_names)),
+    ).fetchall()


### PR DESCRIPTION
Closes #82

## Summary
Foundation for the per-chat label system on words: `labels` and `word_labels` tables (forward-only, idempotent migration with cascade FKs) plus five DAO helpers in `vocab.py`. The "one POS per word" rule is enforced inside `attach_label` via an atomic detach-then-insert. No user-facing commands.

## Test plan
- [x] Stage 2 added schema + cascade tests in `tests/test_db.py` (AC1, AC2, AC3, AC6) and DAO behaviour tests in `tests/test_vocab.py` (AC4, AC5 + edge/error cases)
- [x] `pytest` is green (393 passed)