### PR TITLE
feat: CSV import/export label round-trip

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -483,6 +483,8 @@ async def cmd_import(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         "• Optional second column `translation` is honoured when the header "
         "is `text,translation`; missing translations get backfilled "
         "automatically on next start.\n"
+        "• Optional third column `labels` (header `text,translation,labels`) "
+        "is a `;`-separated list of label names — round-trips with /export.\n"
         "• A bare `text` header (or no header) still works.\n"
         "• Existing words are kept; duplicates are skipped.\n"
         f"(Times out in {int(IMPORT_PENDING_TTL // 60)} minutes; "
@@ -501,7 +503,10 @@ async def cmd_export(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
             "Your vocab is empty. Add words with /add or /import."
         )
         return
-    csv_text = vocab.format_csv([(r["text"], r["translation"]) for r in rows])
+    label_map = vocab.labels_for_words_in_chat(conn, chat_id)
+    csv_text = vocab.format_csv(
+        [(r["text"], r["translation"], label_map.get(r["id"], [])) for r in rows]
+    )
     today = datetime.date.today().isoformat()
     filename = f"vocab-{today}.csv"
     await update.message.reply_document(
@@ -550,28 +555,39 @@ async def on_document(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await update.message.reply_text(f"⚠️ Could not decode file as UTF-8: {e}")
         return
     try:
-        pairs = vocab.parse_csv_words(text)
+        triples = vocab.parse_csv_words(text)
     except csv.Error as e:
         await update.message.reply_text(f"⚠️ Could not parse CSV: {e}")
         return
-    if not pairs:
+    if not triples:
         await update.message.reply_text("No words found in the file.")
         return
-    if len(pairs) > IMPORT_MAX_ROWS:
+    if len(triples) > IMPORT_MAX_ROWS:
         await update.message.reply_text(
-            f"⚠️ Too many rows ({len(pairs)}; max {IMPORT_MAX_ROWS})."
+            f"⚠️ Too many rows ({len(triples)}; max {IMPORT_MAX_ROWS})."
         )
         return
-    words = [w for w, _ in pairs]
-    translations = [t for _, t in pairs]
-    counts = vocab.add_words_bulk(conn, chat_id, words, translations=translations)
+    counts = vocab.import_rows(conn, chat_id, triples)
     parts = [
         f"added: {counts['added']}",
         f"skipped (duplicate): {counts['skipped']}",
     ]
     if counts["invalid"]:
         parts.append(f"skipped (empty): {counts['invalid']}")
-    await update.message.reply_text("Imported. " + ", ".join(parts) + ".")
+    if counts["rejected"]:
+        parts.append(f"rejected (labels): {counts['rejected']}")
+    reply = "Imported. " + ", ".join(parts) + "."
+    label_errors = counts["label_errors"]
+    if label_errors:
+        shown = label_errors[:3]
+        detail = "; ".join(f"row {idx}: {msg}" for idx, msg in shown)
+        more = (
+            f" (+{len(label_errors) - len(shown)} more)"
+            if len(label_errors) > len(shown)
+            else ""
+        )
+        reply += f"\nLabel errors — {detail}{more}"
+    await update.message.reply_text(reply)
 
 
 async def cmd_translate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1091,3 +1091,503 @@ def test_find_word_id_scopes_to_chat(conn: sqlite3.Connection) -> None:  # AC6 �
     assert a != b, f"per-chat rows must yield distinct ids; got {a} vs {b}"
     # Lookup in a third chat returns None even though other chats have the word.
     assert vocab.find_word_id(conn, CHAT + 999, "horse") is None
+
+
+# --- CSV labels round-trip (issue #87) -------------------------------------
+
+
+def _word_label_count(conn: sqlite3.Connection, chat_id: int) -> int:
+    return conn.execute(
+        "SELECT COUNT(*) AS n FROM word_labels wl "
+        "JOIN words w ON w.id = wl.word_id WHERE w.chat_id = ?",
+        (chat_id,),
+    ).fetchone()["n"]
+
+
+def _labels_table_count(conn: sqlite3.Connection, chat_id: int) -> int:
+    return conn.execute(
+        "SELECT COUNT(*) AS n FROM labels WHERE chat_id = ?", (chat_id,)
+    ).fetchone()["n"]
+
+
+def test_format_csv_with_labels_joins_with_semicolon() -> None:  # AC1-export-cell — labels list joined w/ ";"
+    out = vocab.format_csv(
+        [("apple", "яблоко", ["pos:noun", "type:medicine"])]
+    )
+    assert (
+        out == "text,translation,labels\napple,яблоко,pos:noun;type:medicine\n"
+    ), f"got {out!r}"
+
+
+def test_format_csv_empty_labels_emits_empty_third_cell() -> None:  # AC1-export-cell — empty list → empty cell, never "[]"/"None"
+    out = vocab.format_csv([("banana", None, [])])
+    assert out == "text,translation,labels\nbanana,,\n", f"got {out!r}"
+    assert "[]" not in out, "empty labels must be empty cell, never literal '[]'"
+    assert "None" not in out, "empty labels must be empty cell, never literal 'None'"
+
+
+def test_format_csv_preserves_caller_label_order() -> None:  # AC1-export-cell — labels emitted in order given
+    # Caller's order is honoured (sorting is the caller's responsibility, not format_csv's).
+    out = vocab.format_csv(
+        [("apple", None, ["zeta:last", "alpha:first", "mu:middle"])]
+    )
+    # Find the labels cell line and confirm the ;-join preserves the input ordering.
+    body = out.splitlines()[1]
+    assert body.endswith(",zeta:last;alpha:first;mu:middle"), (
+        f"label order should match caller; got line {body!r}"
+    )
+
+
+def test_format_csv_quotes_label_cell_with_comma() -> None:  # edge — label cell with a comma is CSV-quoted
+    # The csv module must quote any cell that contains a comma; round-tripping
+    # back through parse_csv_words is the cleanest assertion.
+    out = vocab.format_csv([("apple", None, ["weird,name", "pos:noun"])])
+    parsed = vocab.parse_csv_words(out)
+    assert parsed == [("apple", None, ["weird,name", "pos:noun"])], (
+        f"comma in a label name must round-trip via csv quoting; got {parsed!r}"
+    )
+
+
+def test_parse_csv_words_three_col_header_parses_labels() -> None:  # AC2-import-with-labels — 3-col header detected, labels split on ";"
+    out = vocab.parse_csv_words(
+        "text,translation,labels\napple,яблоко,pos:noun;type:fruit\n"
+    )
+    assert out == [("apple", "яблоко", ["pos:noun", "type:fruit"])], f"got {out!r}"
+
+
+def test_parse_csv_words_three_col_header_case_insensitive() -> None:  # AC2 — case-insensitive header detection
+    out = vocab.parse_csv_words(
+        "TEXT,Translation,LABELS\napple,яблоко,pos:noun\n"
+    )
+    assert out == [("apple", "яблоко", ["pos:noun"])], f"got {out!r}"
+
+
+def test_parse_csv_words_three_col_empty_labels_cell() -> None:  # edge — empty labels cell → []
+    out = vocab.parse_csv_words("text,translation,labels\napple,яблоко,\n")
+    assert out == [("apple", "яблоко", [])], (
+        f"empty labels cell must be [] (not [''], not None); got {out!r}"
+    )
+
+
+def test_parse_csv_words_three_col_strips_whitespace_in_labels() -> None:  # edge — "pos:noun ; type:medicine" → both stripped
+    out = vocab.parse_csv_words(
+        "text,translation,labels\napple,,pos:noun ; type:medicine\n"
+    )
+    assert out == [("apple", None, ["pos:noun", "type:medicine"])], (
+        f"whitespace inside labels cell must be stripped; got {out!r}"
+    )
+
+
+def test_parse_csv_words_three_col_drops_trailing_empty_fragment() -> None:  # edge — "pos:noun;" → ["pos:noun"]
+    out = vocab.parse_csv_words("text,translation,labels\napple,,pos:noun;\n")
+    assert out == [("apple", None, ["pos:noun"])], (
+        f"trailing ';' must drop empty fragment; got {out!r}"
+    )
+
+
+def test_parse_csv_words_three_col_lowercases_labels() -> None:  # edge — "POS:Noun" → "pos:noun"
+    out = vocab.parse_csv_words(
+        "text,translation,labels\napple,,POS:Noun;TYPE:Fruit\n"
+    )
+    assert out == [("apple", None, ["pos:noun", "type:fruit"])], (
+        f"labels must be lowercased on parse; got {out!r}"
+    )
+
+
+def test_parse_csv_words_three_col_header_only_returns_empty() -> None:  # AC-rework-header-only — header-only 3-col → []
+    out = vocab.parse_csv_words("text,translation,labels\n")
+    # Spec: "parse_csv_words('text,translation,labels\\n') returns []."
+    assert out == [], f"header-only 3-col must yield []; got {out!r}"
+
+
+def test_parse_csv_words_three_col_handles_crlf() -> None:  # edge — CRLF parses identically to LF
+    crlf = "text,translation,labels\r\napple,яблоко,pos:noun\r\n"
+    lf = "text,translation,labels\napple,яблоко,pos:noun\n"
+    assert vocab.parse_csv_words(crlf) == vocab.parse_csv_words(lf)
+    assert vocab.parse_csv_words(crlf) == [("apple", "яблоко", ["pos:noun"])]
+
+
+def test_labels_for_words_in_chat_returns_sorted_per_word(conn: sqlite3.Connection) -> None:  # API — values sorted ASC per word
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    # Attach in a deliberately non-alphabetic order; the result must come back sorted.
+    for name in ("type:medicine", "pos:noun", "category:fruit"):
+        vocab.attach_label(conn, wid, vocab.get_or_create_label(conn, CHAT, name))
+
+    out = vocab.labels_for_words_in_chat(conn, CHAT)
+    assert out == {wid: ["category:fruit", "pos:noun", "type:medicine"]}, (
+        f"per-word values must be sorted ASC; got {out!r}"
+    )
+
+
+def test_labels_for_words_in_chat_omits_words_with_no_labels(conn: sqlite3.Connection) -> None:  # API — only words with ≥1 label keyed
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT, "banana")  # no labels
+    wid_apple = _word_id(conn, CHAT, "apple")
+    vocab.attach_label(
+        conn, wid_apple, vocab.get_or_create_label(conn, CHAT, "pos:noun")
+    )
+
+    out = vocab.labels_for_words_in_chat(conn, CHAT)
+    assert out == {wid_apple: ["pos:noun"]}, (
+        f"words with no labels must be absent (callers default to []); got {out!r}"
+    )
+
+
+def test_labels_for_words_in_chat_scopes_to_chat(conn: sqlite3.Connection) -> None:  # API — different chats don't leak
+    vocab.add_word(conn, CHAT, "apple")
+    vocab.add_word(conn, CHAT + 1, "apple")
+    wid_a = _word_id(conn, CHAT, "apple")
+    wid_b = _word_id(conn, CHAT + 1, "apple")
+    vocab.attach_label(conn, wid_a, vocab.get_or_create_label(conn, CHAT, "pos:noun"))
+    vocab.attach_label(
+        conn, wid_b, vocab.get_or_create_label(conn, CHAT + 1, "type:medicine")
+    )
+
+    out_a = vocab.labels_for_words_in_chat(conn, CHAT)
+    out_b = vocab.labels_for_words_in_chat(conn, CHAT + 1)
+    assert out_a == {wid_a: ["pos:noun"]}, f"chat A leaked or lost rows; got {out_a!r}"
+    assert out_b == {wid_b: ["type:medicine"]}, f"chat B leaked or lost rows; got {out_b!r}"
+
+
+def test_import_rows_creates_and_attaches_labels(conn: sqlite3.Connection) -> None:  # AC2-import-with-labels — get_or_create + attach
+    counts = vocab.import_rows(
+        conn,
+        CHAT,
+        [("apple", "яблоко", ["pos:noun", "type:fruit"])],
+    )
+    assert counts["added"] == 1
+    assert counts["rejected"] == 0
+    assert counts["label_errors"] == []
+
+    wid = _word_id(conn, CHAT, "apple")
+    assert vocab.labels_for_word(conn, wid) == ["pos:noun", "type:fruit"], (
+        "labels must have been created via get_or_create_label and attached"
+    )
+
+
+def test_import_rows_pre_existing_labels_preserved_additive(conn: sqlite3.Connection) -> None:  # AC2-import-with-labels — additive merge, no deletion
+    # Seed: word with one pre-existing label.
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    vocab.attach_label(
+        conn, wid, vocab.get_or_create_label(conn, CHAT, "category:fruit")
+    )
+
+    # Import the same word with a different label; pre-existing label must survive.
+    vocab.import_rows(conn, CHAT, [("apple", None, ["type:fruit"])])
+
+    after = vocab.labels_for_word(conn, wid)
+    assert "category:fruit" in after, (
+        f"pre-existing label must survive import (additive merge); got {after!r}"
+    )
+    assert "type:fruit" in after, f"new label must be attached; got {after!r}"
+
+
+def test_import_rows_two_col_csv_no_label_changes(conn: sqlite3.Connection) -> None:  # AC2-import-no-labels-column — 2-col leaves label tables alone
+    rows = vocab.parse_csv_words("text,translation\napple,яблоко\nbanana,банан\n")
+    counts = vocab.import_rows(conn, CHAT, rows)
+
+    assert counts["added"] == 2, f"expected 2 added; got {counts!r}"
+    assert counts["rejected"] == 0, f"rejected must be 0 for label-free CSV; got {counts!r}"
+    assert counts["label_errors"] == []
+    assert _labels_table_count(conn, CHAT) == 0, "no labels rows should be created"
+    assert _word_label_count(conn, CHAT) == 0, "no word_labels rows should be created"
+
+
+def test_import_rows_legacy_one_col_no_label_changes(conn: sqlite3.Connection) -> None:  # AC5-backwards-compat — 1-col legacy import
+    rows = vocab.parse_csv_words("text\napple\nbanana\n")
+    counts = vocab.import_rows(conn, CHAT, rows)
+
+    assert counts["added"] == 2, f"got {counts!r}"
+    assert counts["rejected"] == 0
+    assert _labels_table_count(conn, CHAT) == 0
+    assert _word_label_count(conn, CHAT) == 0
+
+
+def test_import_rows_no_header_bare_list_no_label_changes(conn: sqlite3.Connection) -> None:  # AC5-backwards-compat — no-header bare list
+    rows = vocab.parse_csv_words("apple\nbanana\ncherry\n")
+    counts = vocab.import_rows(conn, CHAT, rows)
+
+    assert counts["added"] == 3, f"got {counts!r}"
+    assert counts["rejected"] == 0
+    assert _labels_table_count(conn, CHAT) == 0
+
+
+def test_import_rows_existing_csv_counts_match_add_words_bulk(
+    conn: sqlite3.Connection,
+) -> None:  # AC2-import-no-labels-column — added/skipped/invalid identical to today
+    vocab.add_word(conn, CHAT, "apple")  # pre-existing → should be skipped on import
+
+    rows = vocab.parse_csv_words("apple\nbanana\n   \ncherry\n")
+    counts = vocab.import_rows(conn, CHAT, rows)
+    # apple (skipped, dup); banana (added); blank row dropped at parse, not invalid;
+    # cherry (added). Mirror what add_words_bulk would have produced today.
+    assert counts["added"] == 2, f"added: {counts!r}"
+    assert counts["skipped"] == 1, f"skipped: {counts!r}"
+    assert counts["rejected"] == 0
+    assert counts["label_errors"] == []
+
+
+def test_import_rows_rejects_multi_pos(conn: sqlite3.Connection) -> None:  # AC3-multi-pos-rejected — rejected++, label_errors entry, word NOT inserted
+    counts = vocab.import_rows(
+        conn,
+        CHAT,
+        [("apple", None, ["pos:noun", "pos:verb"])],
+    )
+    assert counts["rejected"] == 1, f"rejected count: {counts!r}"
+    assert counts["added"] == 0, f"multi-pos row must NOT be inserted; got {counts!r}"
+    assert len(counts["label_errors"]) == 1, f"one error expected; got {counts!r}"
+
+    row_idx, msg = counts["label_errors"][0]
+    assert row_idx == 1, f"row index must be 1-based; got {row_idx}"
+    assert "pos" in msg.lower(), f"message should mention POS; got {msg!r}"
+
+    # The word was NOT inserted.
+    found = conn.execute(
+        "SELECT 1 FROM words WHERE chat_id = ? AND text = 'apple'", (CHAT,)
+    ).fetchone()
+    assert found is None, "rejected row's word must not be in the words table"
+
+
+def test_import_rows_continues_after_rejection(conn: sqlite3.Connection) -> None:  # AC3 — following rows still imported
+    counts = vocab.import_rows(
+        conn,
+        CHAT,
+        [
+            ("apple", None, ["pos:noun", "pos:verb"]),  # rejected
+            ("banana", None, ["type:fruit"]),  # imported normally
+            ("cherry", None, []),  # imported, no labels
+        ],
+    )
+    assert counts["rejected"] == 1, f"got {counts!r}"
+    assert counts["added"] == 2, (
+        f"banana + cherry must import despite apple being rejected; got {counts!r}"
+    )
+
+    # banana exists with type:fruit attached; cherry exists with no labels; apple absent.
+    banana_id = vocab.find_word_id(conn, CHAT, "banana")
+    cherry_id = vocab.find_word_id(conn, CHAT, "cherry")
+    assert banana_id is not None, "banana must be inserted"
+    assert cherry_id is not None, "cherry must be inserted"
+    assert vocab.find_word_id(conn, CHAT, "apple") is None, "apple must not be inserted"
+    assert vocab.labels_for_word(conn, banana_id) == ["type:fruit"]
+    assert vocab.labels_for_word(conn, cherry_id) == []
+
+
+@pytest.mark.parametrize("bad_label", [":noun", "pos:", "pos:a:b"])
+def test_import_rows_rejects_malformed_label(
+    conn: sqlite3.Connection, bad_label: str
+) -> None:  # AC3-malformed-labels — :noun, pos:, pos:a:b each rejected
+    counts = vocab.import_rows(
+        conn,
+        CHAT,
+        [
+            ("apple", None, [bad_label]),  # rejected
+            ("banana", None, []),  # imported normally
+        ],
+    )
+    assert counts["rejected"] == 1, f"{bad_label!r} should reject; got {counts!r}"
+    assert counts["added"] == 1, (
+        f"banana must still import after apple is rejected for {bad_label!r}; got {counts!r}"
+    )
+    assert len(counts["label_errors"]) == 1
+    row_idx, msg = counts["label_errors"][0]
+    assert row_idx == 1, f"row index must be 1-based; got {row_idx}"
+    assert "malformed" in msg.lower(), (
+        f"message should reference malformed labels; got {msg!r}"
+    )
+
+    # apple was NOT inserted; banana was.
+    assert vocab.find_word_id(conn, CHAT, "apple") is None, (
+        f"row with malformed label {bad_label!r} must not produce a word row"
+    )
+    assert vocab.find_word_id(conn, CHAT, "banana") is not None
+
+
+def test_import_rows_label_error_index_is_one_based(conn: sqlite3.Connection) -> None:  # AC3 — first row's error has row_idx=1
+    counts = vocab.import_rows(
+        conn,
+        CHAT,
+        [
+            ("apple", None, []),  # row 1 — clean
+            ("banana", None, ["pos:noun", "pos:verb"]),  # row 2 — rejected
+            ("cherry", None, [":bad"]),  # row 3 — rejected (malformed)
+        ],
+    )
+    indices = sorted(idx for idx, _ in counts["label_errors"])
+    assert indices == [2, 3], (
+        f"row indices must be 1-based and reference original row position; got {indices!r}"
+    )
+
+
+def test_import_rows_dedupes_duplicate_labels_in_row(conn: sqlite3.Connection) -> None:  # edge — "pos:noun;pos:noun" → not rejected, attached once
+    counts = vocab.import_rows(
+        conn,
+        CHAT,
+        [("apple", None, ["pos:noun", "pos:noun"])],
+    )
+    # Per spec: duplicate labels in same row are deduped, NOT a multi-pos rejection.
+    assert counts["rejected"] == 0, (
+        f"duplicate identical labels must NOT trigger multi-pos rejection; got {counts!r}"
+    )
+    assert counts["added"] == 1, f"got {counts!r}"
+
+    wid = _word_id(conn, CHAT, "apple")
+    assert vocab.labels_for_word(conn, wid) == ["pos:noun"], (
+        "duplicate pos:noun must collapse to one attached label"
+    )
+
+
+def test_import_rows_skips_existing_word_but_attaches_new_labels(
+    conn: sqlite3.Connection,
+) -> None:  # edge — duplicate text → skipped count, labels still attached additively
+    # Seed: existing word with one label.
+    vocab.add_word(conn, CHAT, "apple")
+    wid = _word_id(conn, CHAT, "apple")
+    vocab.attach_label(
+        conn, wid, vocab.get_or_create_label(conn, CHAT, "type:fruit")
+    )
+
+    # Import the same text with a new label.
+    counts = vocab.import_rows(conn, CHAT, [("apple", None, ["pos:noun"])])
+
+    assert counts["added"] == 0, f"existing word must not re-add; got {counts!r}"
+    assert counts["skipped"] == 1, f"existing word must count as skipped; got {counts!r}"
+    after = vocab.labels_for_word(conn, wid)
+    assert sorted(after) == ["pos:noun", "type:fruit"], (
+        f"labels must be additive even when the row is skipped; got {after!r}"
+    )
+
+
+def test_import_rows_empty_input_zero_counts(conn: sqlite3.Connection) -> None:  # edge — [] → all-zero counts, no label_errors
+    counts = vocab.import_rows(conn, CHAT, [])
+    assert counts["added"] == 0
+    assert counts["skipped"] == 0
+    assert counts["invalid"] == 0
+    assert counts["rejected"] == 0
+    assert counts["label_errors"] == []
+
+
+def test_import_rows_does_not_raise_on_bad_row_content(conn: sqlite3.Connection) -> None:  # error — malformed labels propagate via label_errors, not exception
+    # Spec: "import_rows itself never raises on row content; it only raises on
+    # programmer errors (e.g. mismatched argument types)."
+    try:
+        counts = vocab.import_rows(
+            conn,
+            CHAT,
+            [
+                ("apple", None, [":noun"]),
+                ("banana", None, ["pos:noun", "pos:verb"]),
+                ("cherry", None, ["pos:a:b"]),
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001 — spec forbids any raise here
+        pytest.fail(f"import_rows must not raise on bad row content; raised {exc!r}")
+
+    assert counts["rejected"] == 3, (
+        f"all three malformed rows must surface via rejected/label_errors; got {counts!r}"
+    )
+    assert len(counts["label_errors"]) == 3
+
+
+def test_csv_round_trip_preserves_label_set(conn: sqlite3.Connection) -> None:  # AC4 — export → wipe → import reproduces every word's label set
+    # Seed chat A with three words and disjoint label sets.
+    src_chat = CHAT
+    vocab.add_word(conn, src_chat, "apple")
+    vocab.add_word(conn, src_chat, "banana")
+    vocab.add_word(conn, src_chat, "cherry")  # no labels
+    wid_apple = _word_id(conn, src_chat, "apple")
+    wid_banana = _word_id(conn, src_chat, "banana")
+    for name in ("pos:noun", "type:fruit"):
+        vocab.attach_label(
+            conn, wid_apple, vocab.get_or_create_label(conn, src_chat, name)
+        )
+    vocab.attach_label(
+        conn, wid_banana, vocab.get_or_create_label(conn, src_chat, "pos:noun")
+    )
+
+    # Export: build triples the way /export does — labels via labels_for_words_in_chat.
+    label_map = vocab.labels_for_words_in_chat(conn, src_chat)
+    rows = conn.execute(
+        "SELECT id, text, translation FROM words WHERE chat_id = ?", (src_chat,)
+    ).fetchall()
+    triples = [
+        (r["text"], r["translation"], label_map.get(r["id"], [])) for r in rows
+    ]
+    serialized = vocab.format_csv(triples)
+
+    # Round-trip into a fresh chat (the "wipe" simulation).
+    fresh_chat = src_chat + 12345
+    parsed = vocab.parse_csv_words(serialized)
+    counts = vocab.import_rows(conn, fresh_chat, parsed)
+    assert counts["rejected"] == 0, (
+        f"clean export must not reject anything on import; got {counts!r}"
+    )
+
+    # Verify each word's label set matches the source.
+    expected = {
+        "apple": {"pos:noun", "type:fruit"},
+        "banana": {"pos:noun"},
+        "cherry": set(),
+    }
+    for text, want in expected.items():
+        wid = vocab.find_word_id(conn, fresh_chat, text)
+        assert wid is not None, f"{text!r} missing after round-trip import"
+        got = set(vocab.labels_for_word(conn, wid))
+        assert got == want, (
+            f"label set for {text!r} must round-trip exactly; want {want!r}, got {got!r}"
+        )
+
+
+# --- CSV labels rework: header-only short-circuit (issue #87 rework) -------
+
+
+def test_parse_csv_words_three_col_header_only_crlf() -> None:  # AC-rework-header-only-crlf — CRLF header-only → []
+    out = vocab.parse_csv_words("text,translation,labels\r\n")
+    assert out == [], f"CRLF header-only 3-col must yield []; got {out!r}"
+
+
+def test_parse_csv_words_three_col_header_only_mixed_case() -> None:  # AC-rework-header-case — case-insensitive header-only → []
+    out = vocab.parse_csv_words("Text,Translation,Labels\n")
+    assert out == [], f"mixed-case header-only 3-col must yield []; got {out!r}"
+
+
+def test_parse_csv_words_three_col_header_only_then_blank_row() -> None:  # edge — header + whitespace-only row → []
+    # Spec edge: "3-col header followed by one blank/whitespace-only row → still
+    # [] (the blank-row skip already drops it before header detection runs)."
+    out = vocab.parse_csv_words("text,translation,labels\n   \n")
+    assert out == [], f"header + blank row must yield []; got {out!r}"
+
+
+def test_csv_round_trip_empty_chat_is_lossless(conn: sqlite3.Connection) -> None:  # AC4-round-trip-empty — format_csv([]) → parse → import yields zero rows
+    # Empty source: an empty chat has no words.
+    serialized = vocab.format_csv([])
+    parsed = vocab.parse_csv_words(serialized)
+    assert parsed == [], (
+        f"format_csv([]) must round-trip to []; got {parsed!r} from {serialized!r}"
+    )
+
+    fresh_chat = CHAT + 99999
+    counts = vocab.import_rows(conn, fresh_chat, parsed)
+    assert counts["added"] == 0, f"empty round-trip must insert 0 words; got {counts!r}"
+    assert counts["skipped"] == 0, f"empty round-trip must skip 0; got {counts!r}"
+    assert counts["rejected"] == 0, f"empty round-trip must reject 0; got {counts!r}"
+    assert counts["label_errors"] == [], (
+        f"empty round-trip must produce 0 label_errors; got {counts!r}"
+    )
+
+    # Zero words and zero word_labels rows for the fresh chat.
+    word_count = conn.execute(
+        "SELECT COUNT(*) AS n FROM words WHERE chat_id = ?", (fresh_chat,)
+    ).fetchone()["n"]
+    assert word_count == 0, f"empty round-trip must not insert any words; got {word_count}"
+
+    wl_count = conn.execute(
+        "SELECT COUNT(*) AS n FROM word_labels wl "
+        "JOIN words w ON w.id = wl.word_id WHERE w.chat_id = ?",
+        (fresh_chat,),
+    ).fetchone()["n"]
+    assert wl_count == 0, (
+        f"empty round-trip must not insert any word_labels rows; got {wl_count}"
+    )

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -274,46 +274,52 @@ def test_add_words_bulk_scopes_to_chat(conn: sqlite3.Connection) -> None:
 
 def test_parse_csv_words_drops_text_header() -> None:  # AC2-legacy-header (issue #64)
     assert vocab.parse_csv_words("text\napple\nbanana\n") == [
-        ("apple", None),
-        ("banana", None),
+        ("apple", None, []),
+        ("banana", None, []),
     ]
 
 
 def test_parse_csv_words_header_detection_is_case_insensitive() -> None:
-    assert vocab.parse_csv_words("TEXT\napple\n") == [("apple", None)]
+    assert vocab.parse_csv_words("TEXT\napple\n") == [("apple", None, [])]
 
 
 def test_parse_csv_words_keeps_header_when_only_row() -> None:
     # A bare list of one line where that line is "text" must not be eaten as a header.
-    assert vocab.parse_csv_words("text\n") == [("text", None)]
+    assert vocab.parse_csv_words("text\n") == [("text", None, [])]
 
 
 def test_parse_csv_words_accepts_bare_list_without_header() -> None:  # AC2-legacy-bare (issue #64)
     assert vocab.parse_csv_words("apple\nbanana\ncherry\n") == [
-        ("apple", None),
-        ("banana", None),
-        ("cherry", None),
+        ("apple", None, []),
+        ("banana", None, []),
+        ("cherry", None, []),
     ]
 
 
 def test_parse_csv_words_skips_blank_rows_and_blank_first_cells() -> None:
     text = "apple\n\n , extra\nbanana\n"
     # row 2 is fully empty; row 3's first cell is blank (after strip).
-    assert vocab.parse_csv_words(text) == [("apple", None), ("banana", None)]
+    assert vocab.parse_csv_words(text) == [
+        ("apple", None, []),
+        ("banana", None, []),
+    ]
 
 
 def test_parse_csv_words_returns_first_column_only() -> None:
     text = "text,note\napple,fruit\nbanana,yellow\n"
     # `note` is not `translation`, so legacy mode wins and the second column
     # is dropped. Translations come back as None.
-    assert vocab.parse_csv_words(text) == [("apple", None), ("banana", None)]
+    assert vocab.parse_csv_words(text) == [
+        ("apple", None, []),
+        ("banana", None, []),
+    ]
 
 
 def test_parse_csv_words_strips_whitespace_but_preserves_case() -> None:
     # Casing is preserved here; lowercasing happens in add_words_bulk via _normalize.
     assert vocab.parse_csv_words("  Apple  \n  BANANA\n") == [
-        ("Apple", None),
-        ("BANANA", None),
+        ("Apple", None, []),
+        ("BANANA", None, []),
     ]
 
 
@@ -322,31 +328,39 @@ def test_parse_csv_words_empty_input() -> None:
 
 
 def test_format_csv_emits_header_and_sorts_case_insensitively() -> None:
-    out = vocab.format_csv([("banana", None), ("Apple", None), ("cherry", None)])
-    assert out == "text,translation\nApple,\nbanana,\ncherry,\n"
+    out = vocab.format_csv(
+        [("banana", None, []), ("Apple", None, []), ("cherry", None, [])]
+    )
+    assert out == "text,translation,labels\nApple,,\nbanana,,\ncherry,,\n"
 
 
 def test_format_csv_empty_list_still_writes_header() -> None:
-    assert vocab.format_csv([]) == "text,translation\n"
+    assert vocab.format_csv([]) == "text,translation,labels\n"
 
 
 def test_format_csv_uses_lf_line_terminator() -> None:
-    out = vocab.format_csv([("apple", None)])
+    out = vocab.format_csv([("apple", None, [])])
     assert "\r" not in out
     assert out.endswith("\n")
 
 
 def test_format_csv_quotes_cells_with_csv_special_characters() -> None:
     # csv module must escape commas/quotes so the output round-trips cleanly.
-    out = vocab.format_csv([("needs, comma", None), ('has "quote"', None)])
+    out = vocab.format_csv(
+        [("needs, comma", None, []), ('has "quote"', None, [])]
+    )
     assert vocab.parse_csv_words(out) == [
-        ('has "quote"', None),
-        ("needs, comma", None),
+        ('has "quote"', None, []),
+        ("needs, comma", None, []),
     ]
 
 
 def test_csv_round_trip_preserves_words() -> None:
-    rows = [("apple", None), ("banana split", None), ("cherry", None)]
+    rows = [
+        ("apple", None, []),
+        ("banana split", None, []),
+        ("cherry", None, []),
+    ]
     serialized = vocab.format_csv(rows)
     assert sorted(vocab.parse_csv_words(serialized)) == sorted(rows)
 
@@ -582,37 +596,48 @@ def test_add_words_bulk_empty_with_empty_translations(
 
 def test_format_csv_alphabetizes_with_mixed_translations() -> None:  # AC1 — header, alphabetized, None → empty cell never "None"
     out = vocab.format_csv(
-        [("banana", "банан"), ("apple", None), ("Cherry", "вишня")]
+        [
+            ("banana", "банан", []),
+            ("apple", None, []),
+            ("Cherry", "вишня", []),
+        ]
     )
-    assert out == "text,translation\napple,\nbanana,банан\nCherry,вишня\n", (
-        f"unexpected output: {out!r}"
-    )
+    assert (
+        out
+        == "text,translation,labels\napple,,\nbanana,банан,\nCherry,вишня,\n"
+    ), f"unexpected output: {out!r}"
     assert ",None" not in out, "None translation must serialize as empty cell, not literal 'None'"
 
 
 def test_parse_csv_words_two_column_with_translations() -> None:  # AC2-two-col
     out = vocab.parse_csv_words("text,translation\napple,яблоко\nbanana,банан\n")
-    assert out == [("apple", "яблоко"), ("banana", "банан")], f"got {out!r}"
+    assert out == [
+        ("apple", "яблоко", []),
+        ("banana", "банан", []),
+    ], f"got {out!r}"
 
 
 def test_parse_csv_words_two_column_empty_second_cell() -> None:  # AC2-two-col + edge: empty 2nd cell → None
     out = vocab.parse_csv_words("text,translation\napple,яблоко\nbanana,\n")
-    assert out == [("apple", "яблоко"), ("banana", None)], f"got {out!r}"
+    assert out == [
+        ("apple", "яблоко", []),
+        ("banana", None, []),
+    ], f"got {out!r}"
 
 
 def test_parse_csv_words_two_column_header_case_insensitive() -> None:  # AC2-two-col-case
     out = vocab.parse_csv_words("TEXT,Translation\napple,яблоко\n")
-    assert out == [("apple", "яблоко")], f"got {out!r}"
+    assert out == [("apple", "яблоко", [])], f"got {out!r}"
 
 
 def test_add_words_bulk_after_parse_two_col_stores_translations(
     conn: sqlite3.Connection,
 ) -> None:  # AC2-bulk — parse → bulk-insert preserves translations and Nones
-    pairs = vocab.parse_csv_words(
+    triples = vocab.parse_csv_words(
         "text,translation\napple,яблоко\nbanana,\ncherry,вишня\n"
     )
-    words = [text for text, _ in pairs]
-    translations = [tr for _, tr in pairs]
+    words = [text for text, _, _ in triples]
+    translations = [tr for _, tr, _ in triples]
     counts = vocab.add_words_bulk(conn, CHAT, words, translations=translations)
     assert counts == {"added": 3, "skipped": 0, "invalid": 0}, f"got {counts}"
     assert _translation_for(conn, CHAT, "apple") == "яблоко"
@@ -625,9 +650,10 @@ def test_add_words_bulk_after_parse_two_col_stores_translations(
 def test_parse_csv_words_two_column_skips_blank_first_cell() -> None:  # edge: empty first cell in two-col → row skipped
     text = "text,translation\napple,яблоко\n,orphan\nbanana,банан\n"
     out = vocab.parse_csv_words(text)
-    assert out == [("apple", "яблоко"), ("banana", "банан")], (
-        f"row with blank first cell must be dropped; got {out!r}"
-    )
+    assert out == [
+        ("apple", "яблоко", []),
+        ("banana", "банан", []),
+    ], f"row with blank first cell must be dropped; got {out!r}"
 
 
 def test_parse_csv_words_header_only_two_column_returns_legacy_keep_header() -> None:  # edge: header-only two-col input
@@ -635,30 +661,33 @@ def test_parse_csv_words_header_only_two_column_returns_legacy_keep_header() -> 
     # the spec resolves this to legacy single-row keep-header behaviour: the row is
     # treated as data and the first column is returned.
     out = vocab.parse_csv_words("text,translation\n")
-    assert out == [("text", None)], f"got {out!r}"
+    assert out == [("text", None, [])], f"got {out!r}"
 
 
 def test_parse_csv_words_handles_crlf_line_endings() -> None:  # edge: \r\n parses identically to \n
     crlf = "text,translation\r\napple,яблоко\r\nbanana,банан\r\n"
     lf = "text,translation\napple,яблоко\nbanana,банан\n"
     assert vocab.parse_csv_words(crlf) == vocab.parse_csv_words(lf)
-    assert vocab.parse_csv_words(crlf) == [("apple", "яблоко"), ("banana", "банан")]
+    assert vocab.parse_csv_words(crlf) == [
+        ("apple", "яблоко", []),
+        ("banana", "банан", []),
+    ]
 
 
 def test_import_keeps_translation_null_when_csv_lacks_it(
     conn: sqlite3.Connection,
 ) -> None:  # AC3 — None translation survives import as NULL; no mid-import translator call
     # Legacy CSV (single column): every translation parses to None.
-    legacy_pairs = vocab.parse_csv_words("apple\nbanana\n")
-    assert all(tr is None for _, tr in legacy_pairs), f"legacy parse must yield None translations; got {legacy_pairs!r}"
+    legacy = vocab.parse_csv_words("apple\nbanana\n")
+    assert all(tr is None for _, tr, _ in legacy), f"legacy parse must yield None translations; got {legacy!r}"
 
     # Two-column CSV with empty second cells: still None.
-    twocol_pairs = vocab.parse_csv_words("text,translation\ncherry,\ndurian,\n")
-    assert all(tr is None for _, tr in twocol_pairs), f"empty 2nd cells must yield None; got {twocol_pairs!r}"
+    twocol = vocab.parse_csv_words("text,translation\ncherry,\ndurian,\n")
+    assert all(tr is None for _, tr, _ in twocol), f"empty 2nd cells must yield None; got {twocol!r}"
 
-    pairs = legacy_pairs + twocol_pairs
-    words = [text for text, _ in pairs]
-    translations = [tr for _, tr in pairs]
+    triples = legacy + twocol
+    words = [text for text, _, _ in triples]
+    translations = [tr for _, tr, _ in triples]
     vocab.add_words_bulk(conn, CHAT, words, translations=translations)
 
     # Each row's translation column is NULL — backfill (out of scope here) will fill them.
@@ -671,25 +700,31 @@ def test_import_keeps_translation_null_when_csv_lacks_it(
 def test_csv_round_trip_preserves_translations_through_db(
     conn: sqlite3.Connection,
 ) -> None:  # AC4 — export → fresh-chat import → re-export bit-for-bit
-    source = [("Apple", "яблоко"), ("banana", None), ("Cherry", "вишня")]
+    source = [
+        ("Apple", "яблоко", []),
+        ("banana", None, []),
+        ("Cherry", "вишня", []),
+    ]
     serialized = vocab.format_csv(source)
 
     # Import into a fresh chat.
     fresh_chat = CHAT + 9001
-    pairs = vocab.parse_csv_words(serialized)
-    words = [text for text, _ in pairs]
-    translations = [tr for _, tr in pairs]
+    triples = vocab.parse_csv_words(serialized)
+    words = [text for text, _, _ in triples]
+    translations = [tr for _, tr, _ in triples]
     vocab.add_words_bulk(conn, fresh_chat, words, translations=translations)
 
     # Re-export from DB.
     rows = conn.execute(
         "SELECT text, translation FROM words WHERE chat_id = ?", (fresh_chat,)
     ).fetchall()
-    redumped = vocab.format_csv([(r["text"], r["translation"]) for r in rows])
+    redumped = vocab.format_csv(
+        [(r["text"], r["translation"], []) for r in rows]
+    )
 
     # Spec: round-trip preserves the (text_lowercased, translation) set bit-for-bit.
     expected = vocab.format_csv(
-        [(text.lower(), tr) for text, tr in source]
+        [(text.lower(), tr, []) for text, tr, _ in source]
     )
     assert redumped == expected, (
         f"round-trip mismatch:\nexpected:\n{expected!r}\nactual:\n{redumped!r}"
@@ -697,7 +732,11 @@ def test_csv_round_trip_preserves_translations_through_db(
 
 
 def test_csv_round_trip_unicode_preserves_translations() -> None:  # edge: unicode text + translations round-trip
-    rows = [("café", "кофейня"), ("naïve", None), ("Zürich", "Цюрих")]
+    rows = [
+        ("café", "кофейня", []),
+        ("naïve", None, []),
+        ("Zürich", "Цюрих", []),
+    ]
     serialized = vocab.format_csv(rows)
     parsed = vocab.parse_csv_words(serialized)
     assert sorted(parsed) == sorted(rows), (

--- a/vocab.py
+++ b/vocab.py
@@ -227,9 +227,11 @@ def parse_csv_words(text: str) -> list[tuple[str, str | None, list[str]]]:
     if not rows:
         return []
     first_row = rows[0]
+    # 3-col header detection is purely structural — header-only short-circuits
+    # to [] via the empty rows[1:] loop, so the empty-chat round-trip stays
+    # lossless (issue #87).
     is_three_col_header = (
-        len(rows) >= 2
-        and len(first_row) >= 3
+        len(first_row) >= 3
         and first_row[0].lower() == "text"
         and first_row[1].lower() == "translation"
         and first_row[2].lower() == "labels"

--- a/vocab.py
+++ b/vocab.py
@@ -194,21 +194,26 @@ def backfill_translations(
     return {"translated": translated, "failed": failed}
 
 
-def parse_csv_words(text: str) -> list[tuple[str, str | None]]:
-    """Parse a CSV blob into (text, translation_or_None) pairs.
+def parse_csv_words(text: str) -> list[tuple[str, str | None, list[str]]]:
+    """Parse a CSV blob into `(text, translation_or_None, labels)` triples.
 
-    Two-column mode triggers iff the first non-empty row is exactly
-    `text,translation` (case-insensitive, whitespace-stripped on both cells)
-    AND at least one further row exists. In that mode, each subsequent row's
-    second cell becomes the translation; an empty/missing second cell parses
-    to None.
+    Header detection (case-insensitive, whitespace-stripped, only when at
+    least one further row follows) selects mode:
 
-    Otherwise legacy single-column mode: drop a `text`-only header (same rule
-    as before — case-insensitive, only when at least one more row follows),
-    return every remaining row's first cell paired with None translation.
-    Bare lists with no header round-trip too. Blank rows and rows whose first
-    cell is empty after stripping are skipped. Cells are stripped but NOT
-    lowercased — `add_words_bulk` does the normalization.
+    - `text,translation,labels` — three-column mode: each subsequent row's
+      second cell is the translation (None when empty/missing) and the third
+      cell is a `;`-separated list of label names. Each label fragment is
+      stripped and lowercased; empty fragments are dropped; no validation
+      happens here (callers validate via `import_rows`).
+    - `text,translation` — two-column mode: translation parsed as before;
+      labels list is empty for every row.
+    - `text` (single cell) — one-column mode.
+    - No recognised header — bare list; each row's first cell, translation
+      None, labels empty.
+
+    Blank rows and rows whose first cell is empty after stripping are
+    skipped. Cells are stripped but NOT lowercased (label fragments are the
+    one exception) — `add_words_bulk` does the text normalisation.
     """
     reader = csv.reader(io.StringIO(text))
     rows: list[list[str]] = []
@@ -222,6 +227,26 @@ def parse_csv_words(text: str) -> list[tuple[str, str | None]]:
     if not rows:
         return []
     first_row = rows[0]
+    is_three_col_header = (
+        len(rows) >= 2
+        and len(first_row) >= 3
+        and first_row[0].lower() == "text"
+        and first_row[1].lower() == "translation"
+        and first_row[2].lower() == "labels"
+    )
+    if is_three_col_header:
+        out: list[tuple[str, str | None, list[str]]] = []
+        for row in rows[1:]:
+            text_cell = row[0]
+            translation = row[1] if len(row) >= 2 and row[1] else None
+            labels_cell = row[2] if len(row) >= 3 else ""
+            labels = [
+                frag.strip().lower()
+                for frag in labels_cell.split(";")
+                if frag.strip()
+            ]
+            out.append((text_cell, translation, labels))
+        return out
     is_two_col_header = (
         len(rows) >= 2
         and len(first_row) >= 2
@@ -229,30 +254,37 @@ def parse_csv_words(text: str) -> list[tuple[str, str | None]]:
         and first_row[1].lower() == "translation"
     )
     if is_two_col_header:
-        out: list[tuple[str, str | None]] = []
+        two: list[tuple[str, str | None, list[str]]] = []
         for row in rows[1:]:
             text_cell = row[0]
             translation = row[1] if len(row) >= 2 and row[1] else None
-            out.append((text_cell, translation))
-        return out
+            two.append((text_cell, translation, []))
+        return two
     if len(rows) >= 2 and first_row[0].lower() == "text":
         rows = rows[1:]
-    return [(row[0], None) for row in rows]
+    return [(row[0], None, []) for row in rows]
 
 
-def format_csv(rows: list[tuple[str, str | None]]) -> str:
-    """Serialize `(text, translation)` pairs as a CSV string.
+def format_csv(rows: list[tuple[str, str | None, list[str]]]) -> str:
+    """Serialize `(text, translation, labels)` triples as a CSV string.
 
-    Header `text,translation` is always emitted. Rows are sorted
-    case-insensitively by text for stable diffs. A None translation writes an
-    empty second cell — never the literal string `"None"`. Uses `\\n` line
-    terminators for predictable cross-platform output.
+    Header `text,translation,labels` is always emitted. Rows are sorted
+    case-insensitively by text for stable diffs. A None translation writes
+    an empty second cell — never the literal string `"None"`. The labels
+    list is joined with `;` in the order given (callers are expected to
+    sort if they want stable ordering); an empty list writes an empty third
+    cell. Uses `\\n` line terminators for predictable cross-platform
+    output.
     """
     buf = io.StringIO()
     writer = csv.writer(buf, lineterminator="\n")
-    writer.writerow(["text", "translation"])
-    for text, translation in sorted(rows, key=lambda r: r[0].lower()):
-        writer.writerow([text, translation if translation is not None else ""])
+    writer.writerow(["text", "translation", "labels"])
+    for text, translation, labels in sorted(rows, key=lambda r: r[0].lower()):
+        writer.writerow([
+            text,
+            translation if translation is not None else "",
+            ";".join(labels),
+        ])
     return buf.getvalue()
 
 
@@ -617,6 +649,108 @@ def labels_for_word(conn: sqlite3.Connection, word_id: int) -> list[str]:
         (word_id,),
     ).fetchall()
     return [r["name"] for r in rows]
+
+
+def labels_for_words_in_chat(
+    conn: sqlite3.Connection, chat_id: int
+) -> dict[int, list[str]]:
+    """Map every word in `chat_id` that has ≥1 label to its sorted label names.
+
+    One query — used by `/export` to avoid an N+1 over `labels_for_word`.
+    Words with no labels are absent from the result; callers default to `[]`.
+    """
+    rows = conn.execute(
+        "SELECT wl.word_id AS word_id, l.name AS name "
+        "FROM word_labels wl "
+        "JOIN labels l ON l.id = wl.label_id "
+        "JOIN words w ON w.id = wl.word_id "
+        "WHERE w.chat_id = ? "
+        "ORDER BY wl.word_id, l.name ASC",
+        (chat_id,),
+    ).fetchall()
+    out: dict[int, list[str]] = {}
+    for r in rows:
+        out.setdefault(r["word_id"], []).append(r["name"])
+    return out
+
+
+def import_rows(
+    conn: sqlite3.Connection,
+    chat_id: int,
+    rows: list[tuple[str, str | None, list[str]]],
+) -> dict[str, object]:
+    """Import `(text, translation, labels)` triples with per-row label handling.
+
+    For each row, in order:
+
+    - normalise the text; an empty result counts toward `invalid` and the
+      row is skipped.
+    - validate the row's label list via `parse_label_spec` (catches malformed
+      tokens like `:noun`, `pos:`, `pos:a:b`); if validation fails, the row
+      counts toward `rejected` with a `(row_idx, message)` entry in
+      `label_errors` and neither the word nor any labels are inserted.
+    - if the validated label list contains more than one distinct `pos:*`
+      token, the row is `rejected` with a multi-POS message; word is not
+      inserted.
+    - otherwise, insert the word (`INSERT OR IGNORE` — duplicates count
+      toward `skipped` and keep their existing translation) and attach each
+      label additively via `get_or_create_label` + `attach_label`. Labels
+      are merged into existing words; existing labels are preserved.
+
+    Returns `{"added": int, "skipped": int, "invalid": int, "rejected": int,
+    "label_errors": list[(int, str)]}`. `row_idx` is 1-based and counts
+    every input row, including ones rejected for any reason.
+    """
+    ensure_chat(conn, chat_id)
+    added = 0
+    skipped = 0
+    invalid = 0
+    rejected = 0
+    label_errors: list[tuple[int, str]] = []
+    now = _now()
+    for i, (raw_text, translation, raw_labels) in enumerate(rows, start=1):
+        normalized = _normalize(raw_text)
+        if not normalized:
+            invalid += 1
+            continue
+        try:
+            labels = parse_label_spec(list(raw_labels))
+        except ValueError as exc:
+            rejected += 1
+            label_errors.append((i, str(exc)))
+            continue
+        pos_labels = [n for n in labels if n.startswith(POS_PREFIX)]
+        if len(pos_labels) > 1:
+            rejected += 1
+            label_errors.append(
+                (i, "multiple POS labels: " + ", ".join(pos_labels))
+            )
+            continue
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO words(chat_id, text, added_at, translation) "
+            "VALUES (?, ?, ?, ?)",
+            (chat_id, normalized, now, translation),
+        )
+        if cur.rowcount > 0:
+            added += 1
+            word_id = cur.lastrowid
+        else:
+            skipped += 1
+            row = conn.execute(
+                "SELECT id FROM words WHERE chat_id = ? AND text = ?",
+                (chat_id, normalized),
+            ).fetchone()
+            word_id = row["id"]
+        for name in labels:
+            label_id = get_or_create_label(conn, chat_id, name)
+            attach_label(conn, word_id, label_id)
+    return {
+        "added": added,
+        "skipped": skipped,
+        "invalid": invalid,
+        "rejected": rejected,
+        "label_errors": label_errors,
+    }
 
 
 def labels_with_counts(


### PR DESCRIPTION
Closes #87

## Summary
Round-trip per-word labels through `/export` → `/import`. CSVs without a `labels` column continue to import unchanged. 3-col header-only files short-circuit to `[]` so empty-chat round-trip is lossless.

## Test plan
- [x] Stage 2 added tests for AC1–AC5, the rework header-only short-circuit (LF/CRLF/mixed-case), header+blank-row edge, and AC4-round-trip-empty
- [x] `pytest` is green (572 passed)