### PR TITLE
Docs: README + /help + /start onboarding for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,43 @@ A [python-telegram-bot](https://python-telegram-bot.org) app talking to any Open
 | `/clear` | Resets the chat's LLM history. Vocab and settings untouched. |
 | `/add <word or phrase>` | Add a word to this chat's vocab. |
 | `/remove <word or phrase>` | Remove by exact match. |
-| `/list [substring]` | List vocab (least-mentioned first), optionally filtered. |
-| `/import` | Bulk-import from a CSV upload (5-min window, capped at 5000 rows / 1 MB). One word per row in the first column; optional `text` header. Existing words preserved; in-file duplicates skipped. FSRS state not imported. |
-| `/export` | Sends the chat's vocab back as `vocab-YYYY-MM-DD.csv`, alphabetical, with a `text` header. FSRS state not exported. |
+| `/list [<spec>...]` | List vocab (least-mentioned first). With one or more label tokens, restrict to words tagged with **all** of them (AND). See [Labels](#labels). |
+| `/import` | Bulk-import from a CSV upload (5-min window, capped at 5000 rows / 1 MB). Columns: `text` (required), optional `translation`, optional `labels` (`;`-separated names). The `text,translation,labels` header opts in to the three-column round-trip; bare-list and `text,translation` formats remain accepted. Existing words preserved; in-file duplicates skipped; label sets are merged additively. FSRS state not imported. |
+| `/export` | Sends the chat's vocab back as `vocab-YYYY-MM-DD.csv`, alphabetical, with a `text,translation,labels` header. The `labels` column lists each word's labels joined by `;`. FSRS state not exported. |
 | `/resetvocab` | Wipe vocabulary (with a confirm button). |
 | `/translate <text>` | Google-translates args (or replied message) into the chat's target language. Reverse-translates non-Latin input back to English. Inline `➕ Add to vocab` button on results ≤5 words. Bypasses the LLM. |
-| `/games` | Pick a vocab quiz from a 2-button menu: **Word → Translation** or **Translation → Word**. Either runs `min(10, vocab_size)` rounds with 4 inline buttons each (1 correct + 3 distractors); a tap edits the keyboard with ✅/❌ feedback and advances. Final message: `🎯 You scored X/N`. One game per chat at a time; in-memory only (a restart abandons in-flight games). Needs at least 4 translatable vocab rows. |
+| `/games [<spec>...]` | Pick a vocab quiz from a 2-button menu: **Word → Translation** or **Translation → Word**. With one or more label tokens, restrict the pool to words tagged with **all** of them (AND); see [Labels](#labels). Either runs `min(10, pool_size)` rounds with 4 inline buttons each (1 correct + 3 distractors); a tap edits the keyboard with ✅/❌ feedback and advances. Final message: `🎯 You scored X/N`. One game per chat at a time; in-memory only (a restart abandons in-flight games). Needs at least 4 translatable vocab rows in the pool. |
+| `/label <word> <spec>...` | Attach one or more labels to a vocab word. See [Labels](#labels). |
+| `/unlabel <word> <spec>...` | Detach the named labels from a vocab word. |
+| `/labels` | List every label in this chat with its attached-word count. |
+| `/focus [<spec>...]` | Sticky per-chat label spec that scopes scheduled pushes and the post-`❌ forgot` 🎮 button. `/focus pos:noun` sets it; `/focus clear` removes it; `/focus` echoes the current value. |
 | `/status` | Host diagnostics, vocab count, LLM endpoint health, short bench. |
 
 Plain (non-slash) messages hit the LLM with vocab injected into the system prompt as soft hints. Words that appear literally in the reply bump their `mention_count` and get freshness credit.
 
 Scheduled pushes send 1 short snippet using 1 vocab word in the chosen tone, with `✅ knew / ❌ forgot` buttons that apply FSRS `Good` / `Again`.
+
+---
+
+## Labels
+
+Labels are per-chat tags you attach to vocab words. They let you slice your vocabulary by topic, part of speech, or any other axis you invent — and then point `/list`, `/games`, and pushes at just that slice.
+
+**Spec syntax.** A label token is either a bare string (`medicine`, `travel`) or a `key:value` pair (`pos:noun`, `type:animal`). Tokens are stripped + lowercased; a token with internal whitespace, an empty key/value, or more than one colon is rejected with `⚠️ malformed label spec: …` and no writes happen.
+
+**Adding and removing.**
+
+- `/label <word> <spec>...` — attach one or more labels to a word. Lookup is case-insensitive (matches `/remove`). Re-applying an attached label is a no-op (`already attached: …`). Attaching `pos:*` to a word that already carries a different `pos:*` quietly replaces it — a word can only have one `pos:*` at a time.
+- `/unlabel <word> <spec>...` — detach the named labels. Unknown / unattached tokens are silently skipped.
+- `/labels` — list every label in the chat with its attached-word count, alphabetically.
+
+**Filters.** Three commands accept the same spec syntax as a filter; in every case the semantics are **AND across tokens** (words must carry every named label).
+
+- `/list <spec>...` — show only words matching the filter; each row also displays its labels.
+- `/games <spec>...` — restrict the quiz pool to matching words; the chosen filter survives the direction-picker tap. The pool still needs ≥4 translatable rows or the bot replies `no words match those labels — try fewer filters or /label more words`.
+- `/focus <spec>...` — **sticky** per-chat filter that scopes scheduled pushes and the **🎮 Play game** button under the `❌ forgot` explanation. `/focus clear` removes it; `/focus` with no args echoes the current setting. `/list` and `/games` are unaffected by `/focus` — they use only their own inline `<spec>`.
+
+**CSV round-trip.** Labels travel through `/import` and `/export` in a third column named `labels`, with names joined by `;` (semicolon — `,` is already the CSV delimiter). On import the labels for each row are validated with the same spec rules and merged additively into any existing labels for that word; multiple `pos:*` on a single row reject the row. See `/import` and `/export` above for the full column contract.
 
 ---
 

--- a/bot.py
+++ b/bot.py
@@ -307,11 +307,15 @@ HELP_TEXT = (
     "/import (and grab a backup any time with /export). The bot sends short "
     "snippets using those words at random times inside your window.\n"
     "3. Tap ✅ knew / ❌ forgot on each push — ratings drive FSRS spaced "
-    "repetition so tougher words come back more often.\n\n"
+    "repetition so tougher words come back more often.\n"
+    "4. Optional: tag words with /label (e.g. `/label horse pos:noun "
+    "type:animal`) and slice the deck with /list, /games, or /focus.\n\n"
     "Plain (non-slash) messages chat with the model and will naturally reuse "
     "your vocab when it fits.\n\n"
     "*Commands*\n"
     + "\n".join(f"/{name} — {desc}" for name, desc in COMMANDS)
+    + "\n\nLabel syntax + filters: "
+    "https://github.com/valdisd96/teach-me-eng-bot#labels"
 )
 
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -108,7 +108,10 @@ _STEPS = [
 INTRO = "Let's configure your vocab agent.\n\n"
 DONE_MESSAGE = (
     "✅ All set. Add words with `/add <word>` and pushes will start "
-    "showing up in your active window."
+    "showing up in your active window.\n\n"
+    "Tip: tag words with `/label <word> pos:noun type:animal` to slice "
+    "your deck — `/list`, `/games`, and `/focus` all accept the same "
+    "label spec as a filter."
 )
 
 

--- a/tests/test_labels_docs.py
+++ b/tests/test_labels_docs.py
@@ -1,0 +1,160 @@
+"""Tests for issue #88 — README + /help + /start onboarding for labels.
+
+Spec lives in the latest `<!-- agent-plan v1 -->` comment on the issue. This
+suite asserts the runtime-visible doc strings (HELP_TEXT, DONE_MESSAGE) and
+the README sections that describe the label surface introduced in #82–#87.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+
+import bot  # noqa: E402  (env var must be set first)
+import config_flow  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README_TEXT = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+
+def _section(text: str, heading: str) -> str:
+    """Return the slice of `text` under a `## <heading>` line up to the next `## `."""
+    pattern = rf"(?ms)^##\s+{re.escape(heading)}\s*$(.*?)(?=^##\s|\Z)"
+    match = re.search(pattern, text)
+    assert match is not None, f"section '## {heading}' not found in README"
+    return match.group(1)
+
+
+def _split_sections(text: str) -> list[str]:
+    """Yield each `## ...` block (heading included) so we can scan section-locally."""
+    parts = re.split(r"(?m)^(?=##\s)", text)
+    return [p for p in parts if p.strip()]
+
+
+# --- README ----------------------------------------------------------------
+
+
+def test_readme_has_labels_section_heading() -> None:  # AC1 — "## Labels" exists
+    assert re.search(r"(?m)^##\s+Labels\s*$", README_TEXT) is not None, (
+        "README is missing a top-level '## Labels' section heading"
+    )
+
+
+def test_readme_labels_section_documents_convention() -> None:  # AC1(a) — key:value/bare with example
+    section = _section(README_TEXT, "Labels")
+    assert "key:value" in section, "Labels section should describe the key:value convention"
+    # At least one concrete `key:value` example token should appear (e.g. pos:noun).
+    assert re.search(r"\b[a-z]+:[a-z]+\b", section) is not None, (
+        "Labels section should include at least one concrete key:value example"
+    )
+
+
+def test_readme_labels_section_documents_four_commands() -> None:  # AC1(b) — four commands listed
+    section = _section(README_TEXT, "Labels")
+    for cmd in ("/label", "/unlabel", "/labels", "/focus"):
+        assert cmd in section, f"Labels section should document {cmd}"
+
+
+def test_readme_labels_section_documents_and_filtering() -> None:  # AC1(c) — AND across /list, /games, /focus
+    section = _section(README_TEXT, "Labels").lower()
+    assert "and" in section, "Labels section should describe AND-across-tokens filtering"
+    for cmd in ("/list", "/games", "/focus"):
+        assert cmd in section, (
+            f"Labels section should mention {cmd} as accepting the spec syntax"
+        )
+
+
+def test_readme_labels_section_documents_pos_uniqueness() -> None:  # AC1(d) — pos:* uniqueness rule
+    section = _section(README_TEXT, "Labels")
+    assert "pos:" in section, "Labels section should reference the pos:* family"
+    # Some phrasing about a single / one pos:* per word.
+    assert re.search(r"(?i)\bone\b.*\bpos:", section) or re.search(
+        r"(?i)\bsingle\b.*\bpos:", section
+    ) or re.search(r"(?i)pos:.*\b(only|single|one)\b", section), (
+        "Labels section should document the 'one pos:* per word' rule"
+    )
+
+
+def test_readme_csv_section_mentions_labels_column_and_separator() -> None:  # AC4
+    """Some heading-bounded section that documents /import or /export must
+    mention both the literal CSV column name `labels` and the literal `;`
+    separator.
+    """
+    matching = [
+        s
+        for s in _split_sections(README_TEXT)
+        if ("/import" in s or "/export" in s) and "labels" in s and ";" in s
+    ]
+    assert matching, (
+        "Expected at least one README section that documents /import or /export "
+        "to mention both the `labels` CSV column and the `;` separator; found none."
+    )
+
+
+# --- bot.HELP_TEXT ---------------------------------------------------------
+
+
+def test_help_text_lists_four_label_commands_with_descs() -> None:  # AC2 — em-dash + non-empty desc
+    """Every label command must appear as `/<name> — <non-empty>` in HELP_TEXT."""
+    for cmd in ("label", "unlabel", "labels", "focus"):
+        match = re.search(rf"/{cmd} — (\S[^\n]*)", bot.HELP_TEXT)
+        assert match is not None, (
+            f"/{cmd} must appear in HELP_TEXT followed by ' — <description>'"
+        )
+        assert match.group(1).strip(), f"/{cmd} description in HELP_TEXT must be non-empty"
+
+
+def test_help_text_links_to_readme_labels_anchor() -> None:  # AC2 — exact #labels anchor URL
+    assert "github.com/valdisd96/teach-me-eng-bot#labels" in bot.HELP_TEXT, (
+        "HELP_TEXT must link to the README Labels section via the #labels anchor "
+        "(GitHub auto-generates lower-cased anchors from headings)"
+    )
+
+
+# --- config_flow.DONE_MESSAGE ----------------------------------------------
+
+
+def test_done_message_mentions_label_command() -> None:  # AC3 — contains "/label"
+    assert "/label" in config_flow.DONE_MESSAGE, (
+        "DONE_MESSAGE must mention /label so users discover labels right after /start"
+    )
+
+
+def test_done_message_under_400_chars() -> None:  # AC3 — length cap
+    n = len(config_flow.DONE_MESSAGE)
+    assert n <= 400, f"DONE_MESSAGE must stay ≤ 400 chars (was {n})"
+
+
+# --- invariants ------------------------------------------------------------
+
+
+def test_commands_label_tuples_unchanged() -> None:  # invariant — COMMANDS still has the 4 label tuples
+    """COMMANDS must still expose exactly the four label commands, each once,
+    with a non-empty description. The spec forbids adding/removing label
+    commands as part of this docs-only change.
+    """
+    label_cmds = {"label", "unlabel", "labels", "focus"}
+    found = [(name, desc) for name, desc in bot.COMMANDS if name in label_cmds]
+    names = [name for name, _ in found]
+    for cmd in label_cmds:
+        assert names.count(cmd) == 1, (
+            f"COMMANDS must contain /{cmd} exactly once (got {names.count(cmd)})"
+        )
+    for name, desc in found:
+        assert desc.strip(), f"COMMANDS entry /{name} must have a non-empty description"
+
+
+def test_done_message_has_no_fstring_substitutions() -> None:  # invariant — no { } substitutions
+    """DONE_MESSAGE must remain a single string literal — no f-string
+    substitutions added. Easiest observable: it contains no `{` or `}`.
+    """
+    assert "{" not in config_flow.DONE_MESSAGE, (
+        "DONE_MESSAGE must not contain '{' — should remain a static string literal"
+    )
+    assert "}" not in config_flow.DONE_MESSAGE, (
+        "DONE_MESSAGE must not contain '}' — should remain a static string literal"
+    )


### PR DESCRIPTION
Closes #88

## Summary
- New `## Labels` section in `README.md` covering the `key:value` / bare convention, the four label commands, AND-across-tokens filtering, the `pos:*` uniqueness rule, and the CSV labels-column round-trip (`;` separator).
- `/import` and `/export` rows in the commands table updated to mention the `labels` column. Four label-command rows added.
- `bot.HELP_TEXT` getting-started prose now mentions `/label` once; footer line links to the README Labels anchor.
- `config_flow.DONE_MESSAGE` extended with a single-line tip pointing at `/label`.

## Test plan
- [x] Stage 2 added `tests/test_labels_docs.py` (12 tests, AC1–AC4 + invariants)
- [x] `pytest -q` is green (584 passed)