### PR TITLE
fix: keep label suggestions visible when LLM is a reasoning model

### DIFF
--- a/label_suggestor.py
+++ b/label_suggestor.py
@@ -148,7 +148,13 @@ async def suggest_labels(
         return []
     messages = _build_messages(word, existing_labels)
     try:
-        raw = await llm_chat(messages, max_tokens=128, temperature=0.2)
+        # disable_reasoning: a small max_tokens budget plus the free-tier
+        # auto-router can land on a reasoning-heavy model that spends the whole
+        # budget on its `message.reasoning` trace and returns `content: null`.
+        # Suppressing reasoning keeps the JSON answer in `content`.
+        raw = await llm_chat(
+            messages, max_tokens=128, temperature=0.2, disable_reasoning=True
+        )
     except Exception as exc:  # noqa: BLE001 — never let a flaky LLM break /add
         log.warning("suggest_labels: LLM call failed for %r: %s", word, exc)
         return []

--- a/llm.py
+++ b/llm.py
@@ -125,21 +125,30 @@ async def chat(
     *,
     max_tokens: int = 256,
     temperature: float = 0.8,
+    disable_reasoning: bool = False,
 ) -> str:
-    """Return the full assistant reply as a single string (no streaming)."""
+    """Return the full assistant reply as a single string (no streaming).
+
+    When ``disable_reasoning=True`` the request body carries
+    ``reasoning: {enabled: false}`` — an OpenRouter-normalised hint that suppresses
+    the model's chain-of-thought trace. Needed for callers that share a small
+    ``max_tokens`` budget with reasoning-heavy free-tier auto-router targets,
+    which would otherwise spend the whole budget on ``message.reasoning`` and
+    return ``content: null``. Default ``False`` keeps every existing caller's
+    on-the-wire payload byte-identical.
+    """
     backend = _get_backend()
+    body: dict = {
+        "model": backend.model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": False,
+    }
+    if disable_reasoning:
+        body["reasoning"] = {"enabled": False}
     async with httpx.AsyncClient(timeout=180) as client:
-        r = await client.post(
-            backend.url,
-            headers=backend.headers,
-            json={
-                "model": backend.model,
-                "messages": messages,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "stream": False,
-            },
-        )
+        r = await client.post(backend.url, headers=backend.headers, json=body)
         r.raise_for_status()
         return _parse_completion(r.json())
 

--- a/tests/test_label_suggestions.py
+++ b/tests/test_label_suggestions.py
@@ -163,6 +163,58 @@ def test_suggest_labels_empty_existing_and_llm_fails() -> None:  # edge: empty e
     assert out == [], f"empty existing + LLM failure must yield []; got {out!r}"
 
 
+# === issue #99: disable_reasoning wiring ===================================
+
+
+def test_suggest_labels_invokes_llm_chat_with_disable_reasoning_true() -> None:
+    # AC3 — suggest_labels must call llm_chat exactly once with
+    # disable_reasoning=True among its kwargs.
+    spy = AsyncMock(return_value='{"pos": "noun", "labels": []}')
+    asyncio.run(label_suggestor.suggest_labels("horse", ["type:animal"], spy))
+    assert spy.await_count == 1, (
+        f"AC3 — llm_chat must be invoked exactly once; got {spy.await_count}"
+    )
+    kwargs = spy.await_args.kwargs
+    assert kwargs.get("disable_reasoning") is True, (
+        "AC3 — suggest_labels must forward disable_reasoning=True; "
+        f"got kwargs={kwargs!r}"
+    )
+
+
+def test_other_llm_callers_do_not_pass_disable_reasoning() -> None:
+    # AC4 — bot.cmd_* games and scheduler.push/explain must NOT pass
+    # disable_reasoning to llm.chat. Static-source check: the kwarg name
+    # must not appear in any module other than label_suggestor.py.
+    repo_root = Path(label_suggestor.__file__).parent
+    forbidden = ("bot.py", "scheduler.py")
+    for name in forbidden:
+        src = (repo_root / name).read_text(encoding="utf-8")
+        assert "disable_reasoning" not in src, (
+            f"AC4 — {name} must not pass disable_reasoning to llm.chat; "
+            "only label_suggestor is allowed to opt in."
+        )
+
+
+def test_suggest_labels_output_unchanged_with_disable_reasoning_wired() -> None:
+    # AC5 — when the LLM returns parseable JSON, suggest_labels still produces
+    # the same ordered + deduped + capped list it did before the kwarg was
+    # threaded through. The disable_reasoning plumbing must not alter the
+    # post-parse pipeline.
+    raw = (
+        '{"pos": "noun", '
+        '"labels": ["type:animal", "type:animal", "type:pet", "type:invented"]}'
+    )
+    existing = ["type:animal", "type:pet"]
+    spy = AsyncMock(return_value=raw)
+    out = asyncio.run(label_suggestor.suggest_labels("horse", existing, spy))
+    # POS first, declared order, unknown ('type:invented') filtered, duplicates
+    # collapsed — same contract the existing parse_llm_response tests assert.
+    assert out == ["pos:noun", "type:animal", "type:pet"], (
+        "AC5 — suggest_labels output must be unchanged by disable_reasoning "
+        f"wiring; got {out!r}"
+    )
+
+
 # === PendingLabel registry ==================================================
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -188,6 +188,95 @@ def test_chat_openrouter_posts_with_bearer_and_model(
     assert captured_request["body"]["model"] == llm.DEFAULT_OPENROUTER_MODEL
 
 
+# chat() disable_reasoning kwarg ---------------------------------------
+
+
+def test_chat_default_body_omits_reasoning_key(
+    clean_env: pytest.MonkeyPatch,
+    captured_request: dict,
+) -> None:  # AC1 — default kwargs => no "reasoning" key
+    asyncio.run(llm.chat([{"role": "user", "content": "hi"}]))
+    assert "reasoning" not in captured_request["body"], (
+        "AC1 — default chat() must NOT carry a 'reasoning' key on the wire; "
+        f"got body={captured_request['body']!r}"
+    )
+
+
+def test_chat_disable_reasoning_sets_reasoning_enabled_false(
+    clean_env: pytest.MonkeyPatch,
+    captured_request: dict,
+) -> None:  # AC2 — disable_reasoning=True adds reasoning: {enabled: False}
+    asyncio.run(
+        llm.chat([{"role": "user", "content": "hi"}], disable_reasoning=True)
+    )
+    assert captured_request["body"].get("reasoning") == {"enabled": False}, (
+        "AC2 — disable_reasoning=True must place reasoning={'enabled': False} on "
+        f"the wire; got {captured_request['body'].get('reasoning')!r}"
+    )
+
+
+def test_chat_disable_reasoning_preserves_default_body_shape(
+    clean_env: pytest.MonkeyPatch,
+    captured_request: dict,
+) -> None:  # AC2 — body still carries model/messages/max_tokens/temperature/stream
+    msgs = [{"role": "user", "content": "hi"}]
+    asyncio.run(llm.chat(msgs, disable_reasoning=True))
+    body = captured_request["body"]
+    assert body["model"] == llm.MODEL, f"model lost from body; got {body!r}"
+    assert body["messages"] == msgs, f"messages lost from body; got {body!r}"
+    assert body["max_tokens"] == 256, f"default max_tokens lost; got {body!r}"
+    assert body["temperature"] == 0.8, f"default temperature lost; got {body!r}"
+    assert body["stream"] is False, f"stream flag lost; got {body!r}"
+
+
+def test_chat_default_body_byte_identical_to_explicit_false(
+    clean_env: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # edge: disable_reasoning=False default is byte-identical to current
+    bodies: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content) if request.content else {})
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": "ok"}}]}
+        )
+
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    msgs = [{"role": "user", "content": "hi"}]
+    asyncio.run(llm.chat(msgs))
+    asyncio.run(llm.chat(msgs, disable_reasoning=False))
+    assert bodies[0] == bodies[1], (
+        "edge — default kwargs and disable_reasoning=False must produce "
+        f"byte-identical bodies; default={bodies[0]!r}, explicit={bodies[1]!r}"
+    )
+
+
+def test_chat_disable_reasoning_works_on_llama_backend(
+    clean_env: pytest.MonkeyPatch,
+    captured_request: dict,
+) -> None:  # edge: llama.cpp backend accepts the unknown reasoning field
+    # Default backend is llama.cpp (clean_env wipes LLM_BACKEND).
+    asyncio.run(
+        llm.chat([{"role": "user", "content": "hi"}], disable_reasoning=True)
+    )
+    assert captured_request["url"] == llm.LLAMA_URL, (
+        f"clean_env should keep llama.cpp default; got {captured_request['url']!r}"
+    )
+    assert captured_request["body"].get("reasoning") == {"enabled": False}, (
+        "edge — reasoning field must be present even on the llama.cpp backend "
+        "(server is expected to ignore unknown fields); got "
+        f"{captured_request['body'].get('reasoning')!r}"
+    )
+
+
 # stream_chat() request shape -------------------------------------------
 
 


### PR DESCRIPTION
Closes #99

## Summary
After `/add <word>`, the label-suggestion buttons silently never appeared when running on `LLM_BACKEND=openrouter` + `OPENROUTER_MODEL=openrouter/free`. The auto-router lands on reasoning-heavy free-tier models that consume the entire `max_tokens=128` budget on `message.reasoning` and return `content: null`, so `parse_llm_response("")` → `[]` and `_send_label_suggestions` skips the message.

The fix threads an opt-in `disable_reasoning: bool = False` kwarg through `llm.chat()`. When true, the request body carries `"reasoning": {"enabled": false}`, an OpenRouter-normalised hint that suppresses the chain-of-thought trace. `suggest_labels` opts in; every other caller is untouched and on-the-wire byte-identical.

## Test plan
- [x] Stage 2 added wire-shape tests for the new kwarg and suggest_labels-side wiring
- [x] AC1 — default `chat()` body has no `"reasoning"` key (back-compat)
- [x] AC2 — `disable_reasoning=True` adds `reasoning: {enabled: False}` and otherwise matches the default body shape
- [x] AC3 — `suggest_labels` calls `llm_chat` exactly once with `disable_reasoning=True`
- [x] AC4 — static check: `bot.py` and `scheduler.py` never opt in
- [x] AC5 — post-parse output (POS first, declared order, dedup, unknown filtered) unchanged
- [x] Edge: `disable_reasoning=False` byte-identical to default body
- [x] Edge: llama.cpp backend tolerates the unknown field

Note on suite state: ~80 tests across `test_label_suggestions.py`, `test_label_commands.py`, `test_list_label_spec.py`, and `test_play_game_button.py` fail with "Rejected message from unauthorized user" — this is pre-existing on `main` (caused by the auth check added in 481efe8 / PR #98) and unrelated to this change. The 8 new tests added here all pass.