### PR TITLE
chore: bump fabric config to schema 0.2.0

### DIFF
--- a/.fabric/config.yaml
+++ b/.fabric/config.yaml
@@ -59,6 +59,9 @@ pipeline:
   cycle_limit: 5
   retry_count: 3
   retry_backoff_seconds: [60, 300, 900]
-  daily_dispatch_cap: 30
+  # At most 30 dispatches in any rolling 5-hour window — tracks Anthropic's
+  # subscription rate-limit shape so we stay under the wall.
+  dispatch_cap: 30
+  dispatch_window_hours: 5
 
-fabric_version: "0.1.0"
+fabric_version: "0.2.0"

--- a/.github/workflows/fabric-sync-check.yml
+++ b/.github/workflows/fabric-sync-check.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: install agent-fabric
         env:
-          AGENT_FABRIC_SHA: ac2adf3dc881023e0f63780840016a8ac42a45dc
+          AGENT_FABRIC_SHA: c7e91bba1abbd4ae3655dbd3d13a565255031548
         run: |
           pip install "agent-fabric @ git+https://github.com/valdisd96/agent-fabric.git@${AGENT_FABRIC_SHA}"
 


### PR DESCRIPTION
## Summary

- Replaces `pipeline.daily_dispatch_cap: 30` with `pipeline.dispatch_cap: 30` + `pipeline.dispatch_window_hours: 5`.
- Bumps `fabric_version` from `"0.1.0"` to `"0.2.0"`.

## Why

agent-fabric `0.2.0` ([PR #58](https://github.com/valdisd96/agent-fabric/pull/58)) replaces the calendar-day cap with a rolling 5-hour window that tracks Anthropic's subscription rate-limit shape (no more midnight cliff if today's budget burns before noon). The `pipeline` section is `extra="forbid"`, so leaving the old field name in place trips validation:

```
ConfigError: pipeline.daily_dispatch_cap: Extra inputs are not permitted
```

The deployed fabric has been silently skipping this project on every scheduler tick since the 0.2.0 deploy at 18:56:54 UTC today — `fabric/scheduler.py` swallows `ConfigError` with `except Exception: continue`, so there were no log lines or notifications. Issue #102 (and any other open issue) is parked at its current state until this lands.

## Test plan

- [x] Validated locally: `from fabric.config import load_project_config; load_project_config('.')` returns `cap=30 window=5 h fabric_version=0.2.0`.
- [ ] After merge: server-side `cd /srv/projects/teach-me-eng-bot && git pull` → next fabric tick dispatches test-writer for #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)