### PR TITLE
fix: trim /games COMMANDS description below Telegram 256-char limit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -290,7 +290,7 @@ COMMANDS: list[tuple[str, str]] = [
     ("export", "Download this chat's vocab as a CSV file"),
     ("resetvocab", "Wipe this chat's vocabulary (with confirm)"),
     ("translate", "Translate args; tap the button under the reply to add the English word/phrase to vocab"),
-    ("games", "Pick a game: Word → Translation, Translation → Word (vocab quiz, 1–10 rounds; optionally filter by a label spec, AND across tokens), or Irregular verbs (type the past simple + past participle, 1–10 rounds). /games cancel ends an in-flight game so a new one can start."),
+    ("games", "Pick a game: Word → Translation, Translation → Word (vocab quiz, 1–10 rounds; optional label filter, AND across tokens), or Irregular verbs (past simple + past participle, 1–10 rounds). Use /games cancel to end an in-flight game so a new one can start."),
     ("label", "Attach labels to a vocab word (e.g. /label horse pos:noun type:animal)"),
     ("unlabel", "Detach labels from a vocab word"),
     ("labels", "List every label in this chat with its attached-word count"),

--- a/tests/test_commands_telegram_limit.py
+++ b/tests/test_commands_telegram_limit.py
@@ -1,0 +1,108 @@
+"""Tests for issue #108 — `/games` COMMANDS description must stay <= Telegram's 256-char ceiling.
+
+Spec lives in the latest `<!-- agent-plan v1 -->` comment on the issue. Behaviour
+asserted here is derived from that spec, not from `bot.py` bodies. The COMMANDS
+list is module-level public data already exercised by `tests/test_help.py`.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+
+import bot  # noqa: E402  (env var must be set first)
+
+
+# Telegram's setMyCommands API rejects any description longer than this.
+TELEGRAM_DESC_MAX = 256
+
+
+# Snapshot of every COMMANDS entry as it stood BEFORE issue #108's fix, except
+# `"games"` (whose description is the one being rewritten). AC5: drive-by edits
+# to any other entry would diverge from this snapshot and fail.
+EXPECTED_NON_GAMES_ENTRIES: list[tuple[str, str]] = [
+    ("start", "Configure schedule: timezone, pushes/day, active window, tone, target language"),
+    ("help", "Show this help message"),
+    ("add", "Add a word or phrase to this chat's vocab"),
+    ("remove", "Remove a word or phrase from vocab"),
+    ("list", "List vocab words (optionally filter by a label spec, AND across tokens)"),
+    ("import", "Bulk-import vocab from a CSV file (one word per row)"),
+    ("export", "Download this chat's vocab as a CSV file"),
+    ("resetvocab", "Wipe this chat's vocabulary (with confirm)"),
+    ("translate", "Translate args; tap the button under the reply to add the English word/phrase to vocab"),
+    ("label", "Attach labels to a vocab word (e.g. /label horse pos:noun type:animal)"),
+    ("unlabel", "Detach labels from a vocab word"),
+    ("labels", "List every label in this chat with its attached-word count"),
+    ("focus", "Set a sticky label spec scoping pushes + post-/forgot game button (e.g. /focus pos:noun); /focus clear removes it; /focus echoes current"),
+    ("clear", "Reset the chat history (LLM memory)"),
+    ("status", "Show host diagnostics, vocab count, and a short model bench"),
+]
+
+
+EXPECTED_NAMES_IN_ORDER: list[str] = [
+    "start", "help", "add", "remove", "list", "import", "export",
+    "resetvocab", "translate", "games", "label", "unlabel", "labels",
+    "focus", "clear", "status",
+]
+
+
+def _games_desc() -> str:
+    desc = next((d for n, d in bot.COMMANDS if n == "games"), None)
+    assert desc is not None, "COMMANDS must contain a 'games' entry"
+    return desc
+
+
+def test_all_commands_descriptions_within_256_chars() -> None:  # AC1, edge: boundary `<=` not `<`
+    """Every (name, desc) in bot.COMMANDS must satisfy len(desc) <= 256.
+
+    Telegram's setMyCommands API rejects any description over 256 chars; the
+    bot crashes at startup if any entry exceeds the limit. Boundary direction:
+    exactly 256 must pass (hence `<= 256`, not `< 256`).
+    """
+    offenders = [
+        (name, len(desc)) for name, desc in bot.COMMANDS if len(desc) > TELEGRAM_DESC_MAX
+    ]
+    assert not offenders, (
+        f"AC1: every COMMANDS description must be <= {TELEGRAM_DESC_MAX} chars; "
+        f"offenders (name, length): {offenders}"
+    )
+
+
+def test_games_description_mentions_cancel() -> None:  # AC2 — case-insensitive substring "cancel"
+    desc = _games_desc()
+    assert "cancel" in desc.lower(), (
+        f"AC2: /games description must still advertise the cancel sub-command; got {desc!r}"
+    )
+
+
+def test_games_description_mentions_label_filter() -> None:  # AC3 — case-insensitive "label" or "filter"
+    desc = _games_desc().lower()
+    assert "label" in desc or "filter" in desc, (
+        f"AC3: /games description must still mention the label-spec filter; got {desc!r}"
+    )
+
+
+def test_games_description_mentions_irregular_verbs() -> None:  # AC4 — case-insensitive substring "irregular"
+    desc = _games_desc()
+    assert "irregular" in desc.lower(), (
+        f"AC4: /games description must still mention irregular verbs; got {desc!r}"
+    )
+
+
+def test_non_games_entries_byte_for_byte_unchanged() -> None:  # AC5 — drive-by edit guard
+    """Every COMMANDS entry except `games` must match its pre-#108 string exactly."""
+    actual_non_games = [(n, d) for n, d in bot.COMMANDS if n != "games"]
+    assert actual_non_games == EXPECTED_NON_GAMES_ENTRIES, (
+        "AC5: only the /games description should change in #108. Diff:\n"
+        f"  expected: {EXPECTED_NON_GAMES_ENTRIES}\n"
+        f"  actual:   {actual_non_games}"
+    )
+
+
+def test_commands_names_and_ordering_preserved() -> None:  # AC5 / Public API — same names, same order
+    actual_names = [name for name, _ in bot.COMMANDS]
+    assert actual_names == EXPECTED_NAMES_IN_ORDER, (
+        "Public API: COMMANDS must retain the same names in the same order; "
+        f"expected {EXPECTED_NAMES_IN_ORDER}, got {actual_names}"
+    )


### PR DESCRIPTION
Closes #108

## Summary
Telegram's `setMyCommands` API rejects any command description over 256 chars; commit `f985d95` (#107) pushed the `/games` entry to 267 chars, crashing `_post_init` on every restart and looping under systemd. This PR rewrites that single description to fit the ceiling while preserving the user-facing concepts (vocab quiz, label filter, irregular verbs, `/games cancel`).

## Test plan
- [x] Stage 2 added tests for the new code paths in `tests/test_commands_telegram_limit.py`
- [x] AC1: every COMMANDS description fits within 256 chars (boundary asserts `<= 256`)
- [x] AC2/3/4: `/games` description still mentions cancel, the label filter, and irregular verbs
- [x] AC5: every non-games entry is byte-for-byte unchanged (drive-by edit guard)
- [x] `pytest -q` is green (641 tests)