### PR TITLE
chore: fabric sync — pick up plan-exec resume fix

### DIFF
--- a/.claude/skills/epic-decompose/SKILL.md
+++ b/.claude/skills/epic-decompose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: epic-decompose
-description: Decomposition stage for `type:epic` issues at `state:needs-decompose`. Multi-round Socratic Q&A with the user (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files children with `Refs #<parent>`, and parks the parent at `state:tracking`. Children are filed B3-style — child #1 at `state:needs-planning`, the rest at `state:draft` — so the fabric's coordinator can release them one at a time as each predecessor closes. Considers documentation impact during decomposition so the epic doesn't close with stale docs. Does NOT cut branches, write code, or open PRs.
-version: 2.1.0
+description: Decomposition stage for `type:epic` issues at `state:needs-decompose` (or `state:in-progress` on crash-resume). Multi-round Socratic Q&A with the user (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files children with `Refs #<parent>`, and parks the parent at `state:tracking`. Children are filed B3-style — child #1 at `state:needs-planning`, the rest at `state:draft` — so the fabric's coordinator can release them one at a time as each predecessor closes. Considers documentation impact during decomposition so the epic doesn't close with stale docs. Does NOT cut branches, write code, or open PRs.
+version: 2.2.0
 ---
 
 # epic-decompose
@@ -22,7 +22,7 @@ You MUST NOT:
 
 ## Inputs and exit conditions
 
-Dispatched on a `type:epic` parent at `state:needs-decompose`. That's the entry state on the very first dispatch (set by `qualify-issue`) and also the resume state after the user answers a clarification or asks for proposal revisions.
+Dispatched on a `type:epic` parent at `state:needs-decompose`. That's the entry state on the very first dispatch (set by `qualify-issue`) and also the resume state after the user answers a clarification or asks for proposal revisions. Rarely you may also be re-invoked at `state:in-progress` — that means the previous dispatch crashed mid-stream after step 1 set the label but before any state-flipping exit. The decision tree below walks the comment history and reaches the same exit regardless of entry state, so no special handling is needed.
 
 Exits the run by flipping the state label to one of:
 - `state:clarification-needed` — you posted a question, awaiting answer.

--- a/.claude/skills/plan-exec/SKILL.md
+++ b/.claude/skills/plan-exec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-exec
-description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue that is unlabelled (fresh) or at state:needs-planning or state:needs-rework. Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, post a `<!-- agent-plan v1 -->` comment that pairs intent with a behavioural spec, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
-version: 1.2.0
+description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue that is unlabelled (fresh), at state:needs-planning, state:needs-rework, or state:in-progress (resume). Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, post a `<!-- agent-plan v1 -->` comment that pairs intent with a behavioural spec, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
+version: 1.3.0
 ---
 
 # plan-exec
@@ -44,8 +44,9 @@ The valid starting states are:
 - **unlabelled** — fresh issue, never picked up. Treat exactly like `state:needs-planning`. The runner script accepts this as the equivalent of "fresh".
 - `state:needs-planning` — explicitly labelled fresh.
 - `state:needs-rework` — coming back from a Stage-2 bounce or Stage-3 rejection.
+- `state:in-progress` — **resume**. The previous dispatch either parked for clarification (now answered — see the latest non-agent comment) or crashed mid-stream. Pick up where you stopped: do **not** restart from step 1, do **not** re-create a branch that already exists. Skip ahead — see "Resuming at `state:in-progress`" below.
 
-The runner script enforces these are the only inputs; double-check anyway. Flip to in-progress:
+Flip to in-progress (no-op if already there):
 
 ```bash
 gh issue edit <N> \
@@ -53,7 +54,14 @@ gh issue edit <N> \
   --add-label "state:in-progress"
 ```
 
-`gh` silently ignores `--remove-label` for labels not present, so the same command works whether the issue was unlabelled, `state:needs-planning`, or `state:needs-rework`.
+`gh` silently ignores `--remove-label` for labels not present, so the same command works whether the issue was unlabelled, `state:needs-planning`, `state:needs-rework`, or already `state:in-progress`.
+
+**Resuming at `state:in-progress`.** Read all issue comments first. Use the prior progress signals to decide what to skip:
+- `<!-- agent-plan v1 -->` present — your behavioural spec is already posted; do not re-post. Re-read it as your contract.
+- A `**Clarification needed before proceeding**` comment from clarify-issue, followed by a non-agent reply — the question has been answered. Treat the reply as additional spec.
+- A local branch matching `<type>/<topic>` already exists → check it out (`git checkout <branch>`) instead of cutting a new one. If the branch exists only on disk and not on the remote (clarify-issue parks before push), continue committing to it locally.
+
+If none of the above signals exist, the prior dispatch crashed before posting anything substantive. Treat as a fresh `state:needs-planning` cycle.
 
 ### 3. Decide: clarify or proceed?
 

--- a/.github/workflows/fabric-sync-check.yml
+++ b/.github/workflows/fabric-sync-check.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: install agent-fabric
         env:
-          AGENT_FABRIC_SHA: c7e91bba1abbd4ae3655dbd3d13a565255031548
+          AGENT_FABRIC_SHA: 8e59f65b9f146e3c23861f0bd43a4a1933342965
         run: |
           pip install "agent-fabric @ git+https://github.com/valdisd96/agent-fabric.git@${AGENT_FABRIC_SHA}"
 


### PR DESCRIPTION
## Summary

Mechanical `fabric sync` after [agent-fabric#62](https://github.com/valdisd96/agent-fabric/pull/62) merged. Pulls in:

- **plan-exec 1.2.0 → 1.3.0** — accepts `state:in-progress` as a valid input meaning "resume from clarification reply or prior crash"; new "Resuming at \`state:in-progress\`" subsection telling the agent how to detect prior progress (existing \`<!-- agent-plan v1 -->\` comment, existing local branch) and continue rather than restart.
- **epic-decompose 2.1.0 → 2.2.0** — inputs section acknowledges the rare crash-recovery case at \`state:in-progress\` (decision tree already handles it).

This unblocks #112 and any future plan-exec clarification reply.

## Test plan

- [x] Diff is byte-for-byte the rendered output (no hand-edits) — drift CI should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)