### PR TITLE
feat: LLM-judged Repeat grading + 5-round focus drill

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1529,7 +1529,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     rep_game = repeat_games.get(chat_id)
     if rep_game is not None and not rep_game.done:
         rd = rep_game.current()
-        correct = repeat_module.grade_answer(user_text, rd)
+        correct = await repeat_module.grade_answer_llm(user_text, rd)
         if correct:
             reply = f"✅ {rd.expected}"
         else:

--- a/focus_drill.py
+++ b/focus_drill.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, Literal
 
 MIN_ROUNDS = 5
-MAX_ROUNDS = 10
+MAX_ROUNDS = 5
 Direction = Literal["en2ru", "ru2en"]
 
 

--- a/prompts.py
+++ b/prompts.py
@@ -31,6 +31,14 @@ _EXPLAIN_SYSTEM = (
     "sentence that uses it. Two sentences total. No headings, no quotes, no lists."
 )
 
+_GRADE_JUDGE_SYSTEM = (
+    "You judge whether a user-typed translation is acceptable. "
+    "Accept inflection variants, minor synonyms, and missing or extra "
+    "prepositions when the meaning is preserved. Reject if the meaning "
+    "differs or essential content is missing. "
+    "Reply with exactly YES or NO — nothing else."
+)
+
 _JUST_TALK_TAIL = "\nKeep answers short: 1–2 paragraphs at most."
 
 _JUST_TALK_VOCAB = (
@@ -75,6 +83,26 @@ def explain_messages(word: str) -> list[dict]:
     return [
         {"role": "system", "content": _EXPLAIN_SYSTEM},
         {"role": "user", "content": f"Word or phrase: {word}"},
+    ]
+
+
+def grade_translation_messages(
+    prompt: str, expected: str, user_text: str
+) -> list[dict]:
+    """Build YES/NO judge messages for grading a typed translation answer.
+
+    Used by the Repeat (typed) game to tolerate inflection / synonyms /
+    missing prepositions — the LLM is the rubric, not string equality.
+    """
+    user = (
+        f"Prompt shown to user: {prompt}\n"
+        f"Expected answer: {expected}\n"
+        f"User typed: {user_text}\n\n"
+        "Acceptable?"
+    )
+    return [
+        {"role": "system", "content": _GRADE_JUDGE_SYSTEM},
+        {"role": "user", "content": user},
     ]
 
 

--- a/repeat_game.py
+++ b/repeat_game.py
@@ -13,6 +13,9 @@ import random
 from dataclasses import dataclass, field
 from typing import Iterable, Literal
 
+import llm
+import prompts
+
 N_ROUNDS = 5
 Direction = Literal["en2ru", "ru2en"]
 
@@ -107,6 +110,33 @@ def draw_rounds(
 def grade_answer(user_text: str, rd: Round) -> bool:
     """Case-insensitive, whitespace-trimmed equality vs ``rd.expected``."""
     return user_text.strip().casefold() == rd.expected.strip().casefold()
+
+
+async def grade_answer_llm(user_text: str, rd: Round) -> bool:
+    """Tolerant grading via an LLM yes/no judge with a strict-equality fast path.
+
+    Returns True when the case-folded / whitespace-stripped ``user_text``
+    equals ``rd.expected`` (no LLM call), OR when ``llm.chat`` resolves to a
+    reply whose first non-whitespace token equals ``YES`` (case-insensitive).
+    Any other path — explicit ``NO``, unparseable reply, or transport error
+    from ``llm.chat`` — yields False, so a flaky backend degrades to strict
+    equality rather than auto-accepting.
+    """
+    if grade_answer(user_text, rd):
+        return True
+    try:
+        reply = await llm.chat(
+            prompts.grade_translation_messages(
+                rd.prompt, rd.expected, user_text
+            ),
+            max_tokens=4,
+            temperature=0.0,
+            disable_reasoning=True,
+        )
+    except Exception:  # noqa: BLE001 — any failure falls back to strict
+        return False
+    head = reply.strip().split(None, 1)[0].upper() if reply.strip() else ""
+    return head.startswith("YES")
 
 
 def apply_answer(game: Game, correct: bool, *, source_word: str) -> None:

--- a/tests/test_focus_drill.py
+++ b/tests/test_focus_drill.py
@@ -54,7 +54,7 @@ def _fresh_game(n: int = 3) -> fd.Game:
 
 
 def test_draw_rounds_returns_min_max_when_no_n_max_override() -> None:  # AC1 — default n_max=MAX_ROUNDS
-    # 7 translatable rows; default n_max == MAX_ROUNDS (10) → expect 7 rounds
+    # 7 translatable rows; pool > MAX_ROUNDS → caps at MAX_ROUNDS.
     pool = _five_translatable_rows() + [
         _row(6, "book", "книга"),
         _row(7, "tree", "дерево"),
@@ -63,7 +63,6 @@ def test_draw_rounds_returns_min_max_when_no_n_max_override() -> None:  # AC1 �
     assert len(rounds) == min(fd.MAX_ROUNDS, 7), (
         f"expected min(MAX_ROUNDS, 7) rounds, got {len(rounds)}"
     )
-    assert len(rounds) == 7
 
 
 def test_draw_rounds_returns_full_max_when_pool_larger() -> None:  # AC1 + edge: pool > MAX_ROUNDS → MAX_ROUNDS

--- a/tests/test_focus_drill.py
+++ b/tests/test_focus_drill.py
@@ -274,3 +274,25 @@ def test_format_result_with_wrong_includes_line() -> None:  # AC10 — "🎯 You
 
 def test_format_result_zero_score_with_wrong() -> None:  # AC10 + example — "🎯 You scored 0/5\nWrong: a, b"
     assert fd.format_result(0, 5, ["a", "b"]) == "🎯 You scored 0/5\nWrong: a, b"
+
+
+# -- MAX_ROUNDS = 5 (#143 — AC8) ---------------------------------------------
+
+
+def test_max_rounds_constant_is_five() -> None:
+    # AC8 — module-level constant MAX_ROUNDS collapses from 10 to 5.
+    assert fd.MAX_ROUNDS == 5, (
+        f"AC8 — focus_drill.MAX_ROUNDS must equal 5 (was 10); got {fd.MAX_ROUNDS}"
+    )
+
+
+def test_draw_rounds_seven_row_pool_returns_five() -> None:
+    # AC8 — with a 7-row pool, draw_rounds yields exactly 5 rounds (was 7 before).
+    pool = _five_translatable_rows() + [
+        _row(6, "book", "книга"),
+        _row(7, "tree", "дерево"),
+    ]
+    rounds = fd.draw_rounds(pool, rng=random.Random(0))
+    assert len(rounds) == 5, (
+        f"AC8 — 7-row pool must cap at MAX_ROUNDS=5 (was 7 before #143); got {len(rounds)}"
+    )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -69,3 +69,45 @@ def test_just_talk_system_with_vocab_includes_words() -> None:
     out = prompts.just_talk_system("You are helpful.", ["ephemeral", "placid"])
     assert "ephemeral" in out and "placid" in out
     assert "vocabulary list" in out
+
+
+# -- grade_translation_messages (#143 — AC7) ---------------------------------
+
+
+def test_grade_translation_messages_two_dicts_system_user() -> None:
+    # AC7 — exactly 2 dicts; system first, user second.
+    msgs = prompts.grade_translation_messages("cat", "кошка", "кот")
+    assert isinstance(msgs, list), f"AC7 — must return a list, got {type(msgs).__name__}"
+    assert len(msgs) == 2, f"AC7 — must return exactly 2 dicts, got {len(msgs)}"
+    roles = [m["role"] for m in msgs]
+    assert roles == ["system", "user"], (
+        f"AC7 — element 0 must be system, element 1 must be user; got {roles}"
+    )
+
+
+def test_grade_translation_messages_user_contains_inputs() -> None:
+    # AC7 — user-role content embeds prompt, expected, user_text as literal substrings.
+    p, e, u = "to get tired of", "уставший от", "устать"
+    msgs = prompts.grade_translation_messages(p, e, u)
+    user_content = msgs[1]["content"]
+    assert p in user_content, (
+        f"AC7 — prompt {p!r} must appear literally in user content; got {user_content!r}"
+    )
+    assert e in user_content, (
+        f"AC7 — expected {e!r} must appear literally in user content; got {user_content!r}"
+    )
+    assert u in user_content, (
+        f"AC7 — user_text {u!r} must appear literally in user content; got {user_content!r}"
+    )
+
+
+def test_grade_translation_messages_system_has_yes_no_rubric() -> None:
+    # AC7 — system content carries a YES/NO rubric.
+    msgs = prompts.grade_translation_messages("cat", "кошка", "кот")
+    sys_content = msgs[0]["content"]
+    assert "YES" in sys_content, (
+        f"AC7 — system rubric must mention YES verdict; got {sys_content!r}"
+    )
+    assert "NO" in sys_content, (
+        f"AC7 — system rubric must mention NO verdict; got {sys_content!r}"
+    )

--- a/tests/test_repeat_game.py
+++ b/tests/test_repeat_game.py
@@ -1,16 +1,23 @@
-"""Tests for repeat_game.py — typed-answer Repeat mini-game (issue #127).
+"""Tests for repeat_game.py — typed-answer Repeat mini-game (issues #127, #143).
 
 Spec-driven: every assertion ties back to a numbered AC, an enumerated edge
 case, or an error condition from the latest <!-- agent-plan v1 --> comment on
-#127. The Behavioral spec only enumerates ACs for the repeat_game module;
-bot-side wiring (gm:repeat picker button, in-flight session routing,
-under-5-pool reply) is out of scope here.
+the relevant issue. The Behavioral spec only enumerates ACs for the
+repeat_game module; bot-side wiring (gm:repeat picker button, in-flight
+session routing, under-5-pool reply) is out of scope here.
+
+#143 adds AC1..AC6 covering `grade_answer_llm` — an async LLM-judged grader
+with a strict-equality fast path and a YES/NO fallback that degrades safely
+to False on any transport / parse failure. The sync `grade_answer` (AC6) is
+asserted unchanged.
 """
 
 from __future__ import annotations
 
+import asyncio
 import random
 
+import httpx
 import pytest
 
 import repeat_game as rg
@@ -269,3 +276,269 @@ def test_format_result_no_wrong_omits_wrong_line() -> None:  # AC6 — empty wro
 def test_format_result_exact_strings_from_spec_examples() -> None:  # AC6 — exact strings from spec
     assert rg.format_result(3, 5, ["apple", "tree"]) == "🎯 You scored 3/5\nWrong: apple, tree"
     assert rg.format_result(5, 5, []) == "🎯 You scored 5/5"
+
+
+# -- grade_answer_llm (#143 — AC1..AC5 + edges + errors) ---------------------
+#
+# We mock at the architectural seam: `llm.chat` is module-imported by
+# repeat_game (`import llm` then `llm.chat(...)`), so monkeypatching the
+# attribute on the `llm` module is picked up at call-time.
+
+
+class _LLMRecorder:
+    """Tracks llm.chat invocations and replies with a canned string/exception."""
+
+    def __init__(self, reply: object) -> None:
+        self.reply = reply
+        self.calls: list[list[dict]] = []
+
+    async def __call__(self, messages: list[dict], **_kwargs) -> str:
+        self.calls.append(messages)
+        if isinstance(self.reply, BaseException):
+            raise self.reply
+        return self.reply  # type: ignore[return-value]
+
+
+def _patch_llm_chat(monkeypatch: pytest.MonkeyPatch, reply: object) -> _LLMRecorder:
+    import llm as llm_mod
+
+    rec = _LLMRecorder(reply)
+    monkeypatch.setattr(llm_mod, "chat", rec)
+    return rec
+
+
+def _patch_llm_chat_must_not_be_called(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Replace llm.chat with one that fails the test if called. Used for fast-path."""
+    import llm as llm_mod
+
+    state = {"calls": 0}
+
+    async def boom(*_a, **_kw) -> str:
+        state["calls"] += 1
+        raise AssertionError(
+            "AC1 — fast path must not invoke llm.chat for exact matches"
+        )
+
+    monkeypatch.setattr(llm_mod, "chat", boom)
+    return state
+
+
+# --- AC1 — fast path: exact match returns True with no LLM call -------------
+
+
+def test_grade_answer_llm_fast_path_exact_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    # AC1 — exact match returns True without calling llm.chat
+    state = _patch_llm_chat_must_not_be_called(monkeypatch)
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("кошка", rd))
+    assert result is True, f"AC1 — exact match must return True, got {result!r}"
+    assert state["calls"] == 0, (
+        f"AC1 — fast path must skip llm.chat entirely, got {state['calls']} call(s)"
+    )
+
+
+def test_grade_answer_llm_fast_path_strips_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC1 + edge: leading/trailing whitespace stripped on both sides
+    state = _patch_llm_chat_must_not_be_called(monkeypatch)
+    rd = _round(expected="  кошка  ")
+    result = asyncio.run(rg.grade_answer_llm("  кошка ", rd))
+    assert result is True, (
+        f"AC1 — strip both sides on fast path; expected True, got {result!r}"
+    )
+    assert state["calls"] == 0, "edge — whitespace-stripped match must skip llm.chat"
+
+
+def test_grade_answer_llm_fast_path_case_folded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC1 + edge: mixed-case Latin and Cyrillic both case-fold equal
+    state = _patch_llm_chat_must_not_be_called(monkeypatch)
+    rd = _round(expected="Кошка")
+    result = asyncio.run(rg.grade_answer_llm("кОшКа", rd))
+    assert result is True, (
+        f"AC1 — case-fold across Cyrillic must match on fast path, got {result!r}"
+    )
+    assert state["calls"] == 0
+
+
+# --- AC2 — LLM YES verdict --------------------------------------------------
+
+
+def test_grade_answer_llm_yes_returns_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    # AC2 — bare "YES" → True
+    rec = _patch_llm_chat(monkeypatch, "YES")
+    rd = _round(expected="уставший от")
+    result = asyncio.run(rg.grade_answer_llm("устать", rd))
+    assert result is True, f"AC2 — bare YES must return True, got {result!r}"
+    assert len(rec.calls) == 1, (
+        f"AC2 — LLM must be consulted once when fast path misses, got {len(rec.calls)}"
+    )
+
+
+def test_grade_answer_llm_yes_dot_returns_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC2 + edge: "Yes." → True (trailing punctuation on the first token)
+    _patch_llm_chat(monkeypatch, "Yes.")
+    rd = _round(expected="устать")
+    result = asyncio.run(rg.grade_answer_llm("уставший", rd))
+    assert result is True, f"AC2 — 'Yes.' must return True, got {result!r}"
+
+
+def test_grade_answer_llm_yes_comma_explanation_returns_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC2 + edge: "Yes, that works" — first token "Yes," starts with YES
+    _patch_llm_chat(monkeypatch, "Yes, that works")
+    rd = _round(expected="устать")
+    result = asyncio.run(rg.grade_answer_llm("уставший", rd))
+    assert result is True, (
+        f"AC2 — 'Yes, that works' must return True (first token starts with YES), got {result!r}"
+    )
+
+
+def test_grade_answer_llm_lowercase_yes_returns_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC2 + edge: "yes!" → True after upper-casing
+    _patch_llm_chat(monkeypatch, "yes!")
+    rd = _round(expected="устать")
+    result = asyncio.run(rg.grade_answer_llm("уставший", rd))
+    assert result is True, f"AC2 — 'yes!' must return True after upper, got {result!r}"
+
+
+# --- AC3 — LLM NO verdict ---------------------------------------------------
+
+
+def test_grade_answer_llm_no_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    # AC3 — "NO" → False
+    _patch_llm_chat(monkeypatch, "NO")
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, f"AC3 — bare NO must return False, got {result!r}"
+
+
+def test_grade_answer_llm_maybe_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC3 + edge: "maybe" — first token does not start with YES → False
+    _patch_llm_chat(monkeypatch, "maybe")
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, f"AC3 — 'maybe' must return False, got {result!r}"
+
+
+def test_grade_answer_llm_perhaps_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC3 + edge: "perhaps" — first token does not start with YES → False
+    _patch_llm_chat(monkeypatch, "perhaps")
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, f"AC3 — 'perhaps' must return False, got {result!r}"
+
+
+# --- AC4 — exception path collapses to False --------------------------------
+
+
+def test_grade_answer_llm_request_error_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC4 + error: httpx.RequestError → False, no propagation
+    _patch_llm_chat(monkeypatch, httpx.ConnectError("simulated"))
+    rd = _round(expected="кошка")
+    # Must NOT raise.
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, (
+        f"AC4 — transport error must collapse to False (strict-equality fallback), got {result!r}"
+    )
+
+
+def test_grade_answer_llm_http_status_error_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC4 + error: httpx.HTTPStatusError → False
+    fake_req = httpx.Request("POST", "http://x.local/")
+    fake_resp = httpx.Response(503, request=fake_req)
+    _patch_llm_chat(
+        monkeypatch, httpx.HTTPStatusError("503", request=fake_req, response=fake_resp)
+    )
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, f"AC4 — HTTPStatusError must collapse to False, got {result!r}"
+
+
+def test_grade_answer_llm_keyerror_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC4 + error: KeyError on response shape → False
+    _patch_llm_chat(monkeypatch, KeyError("choices"))
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, f"AC4 — KeyError must collapse to False, got {result!r}"
+
+
+def test_grade_answer_llm_generic_exception_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC4 — any other exception type → False
+    _patch_llm_chat(monkeypatch, RuntimeError("anything else"))
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, (
+        f"AC4 — generic exception must collapse to False, got {result!r}"
+    )
+
+
+# --- AC5 — unparseable replies collapse to False ----------------------------
+
+
+def test_grade_answer_llm_empty_reply_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC5 + edge: "" reply → False (no first token)
+    _patch_llm_chat(monkeypatch, "")
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, f"AC5 — empty reply must yield False, got {result!r}"
+
+
+def test_grade_answer_llm_whitespace_reply_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # AC5 + edge: "   " whitespace-only reply → False
+    _patch_llm_chat(monkeypatch, "   ")
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("собака", rd))
+    assert result is False, (
+        f"AC5 — whitespace-only reply must yield False, got {result!r}"
+    )
+
+
+# --- edge — empty user input is not an exact match; falls through to LLM ----
+
+
+def test_grade_answer_llm_empty_user_input_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # edge: "" user input vs non-empty expected → fast-path miss → LLM consulted
+    rec = _patch_llm_chat(monkeypatch, "NO")
+    rd = _round(expected="кошка")
+    result = asyncio.run(rg.grade_answer_llm("", rd))
+    assert result is False, f"edge — empty input + NO verdict must return False, got {result!r}"
+    assert len(rec.calls) == 1, (
+        f"edge — empty input is not an exact match; LLM must be consulted exactly once, got {len(rec.calls)}"
+    )
+
+
+# --- AC6 — sync grade_answer is unchanged -----------------------------------
+
+
+def test_grade_answer_sync_unchanged_semantics() -> None:
+    # AC6 — sync grade_answer kept its signature and case-fold/strip equality.
+    # Signature check: still takes (user_text, rd) and returns bool.
+    import inspect
+
+    sig = inspect.signature(rg.grade_answer)
+    params = list(sig.parameters)
+    assert params == ["user_text", "rd"], (
+        f"AC6 — sync grade_answer signature must be (user_text, rd); got {params}"
+    )
+    assert not inspect.iscoroutinefunction(rg.grade_answer), (
+        "AC6 — sync grade_answer must remain synchronous (focus-drill still uses it)"
+    )
+    # Semantic check: strict case-fold/strip equality unchanged.
+    rd = _round(expected="кошка")
+    assert rg.grade_answer("Кошка", rd) is True, "AC6 — case-insensitive equality"
+    assert rg.grade_answer("  кошка  ", rd) is True, "AC6 — strip applies to user input"
+    assert rg.grade_answer("уставший", rd) is False, (
+        "AC6 — strict semantics: synonyms/inflection variants still rejected by sync grader"
+    )


### PR DESCRIPTION
Closes #143

## Summary
- `repeat_game.grade_answer_llm` — async grader with strict-equality fast path
  (no LLM call when answers match case-folded) and YES/NO LLM judge fallback;
  any transport or parse failure collapses to False (degrades to old strict
  behaviour, never a false positive).
- `prompts.grade_translation_messages` — new yes/no judge messages.
- `bot.py` awaits the new helper at the Repeat (typed) branch only;
  focus-drill keeps strict equality.
- `focus_drill.MAX_ROUNDS = 5` (collapsed from variable 5-10).

## Test plan
- [x] Stage 2 added tests covering AC1..AC8 (fast-path, YES/NO parsing,
      transport/parse/generic-exception fallback, sync-grader unchanged,
      grade_translation_messages shape, MAX_ROUNDS=5)
- [x] `pytest` is green (918 passed)